### PR TITLE
Define `permute` as an alias for `aligndims`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensorBase"
 uuid = "4795dd04-0d67-49bb-8f44-b89c448a1dc7"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/quirks.jl
+++ b/src/quirks.jl
@@ -3,20 +3,25 @@ dag(i::Index) = i
 # TODO: Define this properly.
 dag(a::ITensor) = a
 # TODO: Deprecate.
-dim(i::Index) = dename(length(i))
+# Conversion to `Int` is used in case the output is named.
+dim(i::Index) = Int(length(i))
 # TODO: Deprecate.
-dim(a::AbstractITensor) = unname(length(a))
+# Conversion to `Int` is used in case the output is named.
+dim(a::AbstractITensor) = Int(length(a))
 # TODO: Define this properly.
 hasqns(i::Index) = false
 # TODO: Define this properly.
 hasqns(i::AbstractITensor) = false
-# TODO: Deprecate.
+# TODO: Deprecate, and/or decide on aliasing behavior of `ITensor`.
 itensor(parent::AbstractArray, nameddimsindices) = ITensor(parent, nameddimsindices)
 function itensor(parent::AbstractArray, i1::Index, i_rest::Index...)
   return ITensor(parent, (i1, i_rest...))
 end
 # TODO: Deprecate.
 order(a::AbstractArray) = ndims(a)
+# TODO: Deprecate.
+using NamedDimsArrays: aligndims
+permute(a::AbstractITensor, dimnames) = aligndims(a, dimnames)
 
 # This seems to be needed to get broadcasting working.
 # TODO: Investigate this and see if we can get rid of it.


### PR DESCRIPTION
Define `permute` as an alias for `aligndims`. That is the old name for `aligndims` in `ITensors.jl`, which should be deprecated in favor of `aligndims`.