### PR TITLE
Change `onehot` to `oneelement`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensorBase"
 uuid = "4795dd04-0d67-49bb-8f44-b89c448a1dc7"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.1.13"
+version = "0.1.14"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/abstractitensor.jl
+++ b/src/abstractitensor.jl
@@ -91,6 +91,24 @@ function ITensor(parent::AbstractArray)
   return ITensor(parent, ())
 end
 
+# TODO:
+# 1. Generalize this to arbitrary dimensions.
+# 2. Define a basic non-ITensor version in `SparseArraysBase.jl`,
+#    and this constructor can wrap that one. It could construct
+#    a `OneElement` sparse object like `FillArrays.OneElement`
+#    (https://juliaarrays.github.io/FillArrays.jl/stable/#FillArrays.OneElement).
+# 3. Define `oneelement(value, index::Tuple{Vargarg{Int}}, axes::Tuple{Vararg{Index}})`,
+#    where the pair version calls out to that one.
+function oneelement(elt::Type{<:Number}, iv::Pair{<:Index,<:Int})
+  a = ITensor(first(iv))
+  a[last(iv)] = one(elt)
+  return a
+end
+# TODO: The non-ITensor version should default to `Float64`,
+# like `FillArrays.OneElement`.
+# TODO: Make the element type `UnspecifiedOne`.
+oneelement(iv::Pair{<:Index,<:Int}) = oneelement(Bool, iv)
+
 using Accessors: @set
 setdenamed(a::ITensor, denamed) = (@set a.parent = denamed)
 setdenamed!(a::ITensor, denamed) = (a.parent = denamed)

--- a/src/quirks.jl
+++ b/src/quirks.jl
@@ -1,31 +1,30 @@
 # TODO: Define this properly.
+# TODO: Rename this to `dual`.
 dag(i::Index) = i
 # TODO: Define this properly.
+# TODO: Rename this to `dual`.
 dag(a::ITensor) = a
-# TODO: Deprecate.
+
+# TODO: Deprecate, just use `Int(length(i))` or
+# `unname(length(i))` directly.
 # Conversion to `Int` is used in case the output is named.
 dim(i::Index) = Int(length(i))
 # TODO: Deprecate.
 # Conversion to `Int` is used in case the output is named.
+# TODO: Deprecate, just use `Int(length(i))` or
+# `unname(length(i))` directly.
 dim(a::AbstractITensor) = Int(length(a))
+
 # TODO: Define this properly.
-hasqns(i::Index) = false
+# TODO: Maybe rename to `isgraded(i::Index) = isgraded(dename(i))`.
+hasqns(::Index) = false
 # TODO: Define this properly.
-hasqns(i::AbstractITensor) = false
+# TODO: Maybe rename to `isgraded(a) = all(isgraded, axes(a))`.
+hasqns(::AbstractITensor) = false
 
 # This seems to be needed to get broadcasting working.
 # TODO: Investigate this and see if we can get rid of it.
 Base.Broadcast.extrude(a::AbstractITensor) = a
-
-# TODO: Generalize this.
-# Maybe define it as `oneelement`, and base it on
-# `FillArrays.OneElement` (https://juliaarrays.github.io/FillArrays.jl/stable/#FillArrays.OneElement).
-function onehot(elt::Type{<:Number}, iv::Pair{<:Index,<:Int})
-  a = ITensor(first(iv))
-  a[last(iv)] = one(elt)
-  return a
-end
-onehot(iv::Pair{<:Index,<:Int}) = onehot(Bool, iv)
 
 # TODO: This is just a stand-in for truncated SVD
 # that only makes use of `maxdim`, just to get some

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -1,5 +1,16 @@
 using ITensorBase:
-  ITensorBase, ITensor, Index, gettag, hastag, inds, plev, prime, settag, tags, unsettag
+  ITensorBase,
+  ITensor,
+  Index,
+  gettag,
+  hastag,
+  inds,
+  oneelement,
+  plev,
+  prime,
+  settag,
+  tags,
+  unsettag
 using DiagonalArrays: δ, delta, diagview
 using NamedDimsArrays: dename, name, named
 using Test: @test, @test_broken, @testset
@@ -34,6 +45,27 @@ using Test: @test, @test_broken, @testset
     @test dename(i) == 1:2
     @test plev(i) == 0
     @test length(tags(i)) == 0
+  end
+  @testset "oneelement" begin
+    i = Index(3)
+    a = oneelement(i => 2)
+    @test a isa ITensor
+    @test ndims(a) == 1
+    @test issetequal(inds(a), (i,))
+    @test eltype(a) === Bool
+    @test a[1] == 0
+    @test a[2] == 1
+    @test a[3] == 0
+
+    i = Index(3)
+    a = oneelement(Float32, i => 2)
+    @test a isa ITensor
+    @test ndims(a) == 1
+    @test issetequal(inds(a), (i,))
+    @test eltype(a) === Float32
+    @test a[1] == 0
+    @test a[2] == 1
+    @test a[3] == 0
   end
   @testset "delta" begin
     i, j = Index.((2, 2))


### PR DESCRIPTION
`onehot` isn't quite right for the ITensor constructor that creates a tensor with a single nonzero element, see [OneHotArrays.jl](https://github.com/FluxML/OneHotArrays.jl).

There is precedent from `FillArrays.jl` and `Zygote.jl` for calling a sparse array with a single nonzero element `OneElement` (https://github.com/JuliaArrays/FillArrays.jl), so here I am changing `onehot` to `oneelement`.

See also #5, https://github.com/ITensor/SparseArraysBase.jl/issues/24.