### PR TITLE
Define `hasqns`, delete `dag` in favor of `GradedUnitRanges.dag`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensorBase"
 uuid = "4795dd04-0d67-49bb-8f44-b89c448a1dc7"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.1.14"
+version = "0.1.15"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
@@ -16,10 +16,12 @@ VectorInterface = "409d34a3-91d5-4945-b6ec-7529ddf182d8"
 
 [weakdeps]
 DiagonalArrays = "74fd4be6-21e2-4f6f-823a-4360d37c7a77"
+GradedUnitRanges = "e2de450a-8a67-46c7-b59c-01d5a3d041c5"
 SparseArraysBase = "0d5efcca-f356-4864-8770-e1ed8d78f208"
 
 [extensions]
 ITensorBaseDiagonalArraysExt = "DiagonalArrays"
+ITensorBaseGradedUnitRangesExt = "GradedUnitRanges"
 ITensorBaseSparseArraysBaseExt = ["NamedDimsArrays", "SparseArraysBase"]
 
 [compat]
@@ -27,6 +29,7 @@ Accessors = "0.1.39"
 DerivableInterfaces = "0.3.7"
 DiagonalArrays = "0.2.3"
 FillArrays = "1.13.0"
+GradedUnitRanges = "0.1.4"
 LinearAlgebra = "1.10"
 MapBroadcast = "0.1.5"
 NamedDimsArrays = "0.4"

--- a/ext/ITensorBaseGradedUnitRangesExt/ITensorBaseGradedUnitRangesExt.jl
+++ b/ext/ITensorBaseGradedUnitRangesExt/ITensorBaseGradedUnitRangesExt.jl
@@ -1,0 +1,10 @@
+module ITensorBaseGradedUnitRangesExt
+
+using GradedUnitRanges: AbstractGradedUnitRange
+using ITensorBase: ITensorBase
+
+# TODO: Replace with a more general functionality in
+# `GradedUnitRanges`, like `isgraded`.
+ITensorBase.hasqns(r::AbstractGradedUnitRange) = true
+
+end

--- a/src/quirks.jl
+++ b/src/quirks.jl
@@ -1,9 +1,4 @@
-# TODO: Define this properly.
-# TODO: Rename this to `dual`.
-dag(i::Index) = i
-# TODO: Define this properly.
-# TODO: Rename this to `dual`.
-dag(a::ITensor) = a
+using NamedDimsArrays: dename
 
 # TODO: Deprecate, just use `Int(length(i))` or
 # `unname(length(i))` directly.
@@ -15,12 +10,11 @@ dim(i::Index) = Int(length(i))
 # `unname(length(i))` directly.
 dim(a::AbstractITensor) = Int(length(a))
 
-# TODO: Define this properly.
-# TODO: Maybe rename to `isgraded(i::Index) = isgraded(dename(i))`.
-hasqns(::Index) = false
-# TODO: Define this properly.
-# TODO: Maybe rename to `isgraded(a) = all(isgraded, axes(a))`.
-hasqns(::AbstractITensor) = false
+# TODO: Replace with a more general functionality in
+# `GradedUnitRanges`, like `isgraded`.
+hasqns(r::AbstractUnitRange) = false
+hasqns(i::Index) = hasqns(dename(i))
+hasqns(a::AbstractITensor) = all(hasqns, inds(a))
 
 # This seems to be needed to get broadcasting working.
 # TODO: Investigate this and see if we can get rid of it.

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,12 +1,16 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
+BlockSparseArrays = "2c9a651f-6452-4ace-a6ac-809f4280fbb4"
 DiagonalArrays = "74fd4be6-21e2-4f6f-823a-4360d37c7a77"
+GradedUnitRanges = "e2de450a-8a67-46c7-b59c-01d5a3d041c5"
 ITensorBase = "4795dd04-0d67-49bb-8f44-b89c448a1dc7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NamedDimsArrays = "60cbd0c0-df58-4cb7-918c-6f5607b73fde"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SparseArraysBase = "0d5efcca-f356-4864-8770-e1ed8d78f208"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
+SymmetrySectors = "f8a8ad64-adbc-4fce-92f7-ffe2bb36a86e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -3,7 +3,18 @@ using BlockSparseArrays: BlockSparseArray
 using DiagonalArrays: δ, delta, diagview
 using GradedUnitRanges: dual, gradedrange
 using ITensorBase:
-  ITensorBase, ITensor, Index, gettag, hastag, hasqns, inds, plev, prime, settag, tags, unsettag
+  ITensorBase,
+  ITensor,
+  Index,
+  gettag,
+  hastag,
+  hasqns,
+  inds,
+  plev,
+  prime,
+  settag,
+  tags,
+  unsettag
 using NamedDimsArrays: dename, name, named
 using SparseArraysBase: oneelement
 using SymmetrySectors: U1

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -1,8 +1,12 @@
-using ITensorBase:
-  ITensorBase, ITensor, Index, gettag, hastag, inds, plev, prime, settag, tags, unsettag
+using BlockArrays: Block
+using BlockSparseArrays: BlockSparseArray
 using DiagonalArrays: δ, delta, diagview
+using GradedUnitRanges: dual, gradedrange
+using ITensorBase:
+  ITensorBase, ITensor, Index, gettag, hastag, hasqns, inds, plev, prime, settag, tags, unsettag
 using NamedDimsArrays: dename, name, named
 using SparseArraysBase: oneelement
+using SymmetrySectors: U1
 using Test: @test, @test_broken, @testset
 
 @testset "ITensorBase" begin
@@ -74,5 +78,24 @@ using Test: @test, @test_broken, @testset
     @test a[1] == 0
     @test a[2] == 1
     @test a[3] == 0
+  end
+  @testset "hasqns" begin
+    i = Index(2)
+    j = Index(2)
+    a = ITensor(randn(2, 2), (i, j))
+    @test !hasqns(i)
+    @test !hasqns(j)
+    @test !hasqns(a)
+
+    r = gradedrange([U1(0) => 2, U1(1) => 2])
+    d = BlockSparseArray{Float64}(r, dual(r))
+    d[Block(1, 1)] = randn(2, 2)
+    d[Block(2, 2)] = randn(2, 2)
+    i = Index(r)
+    j = Index(dual(r))
+    a = ITensor(d, (i, j))
+    @test hasqns(i)
+    @test hasqns(j)
+    @test hasqns(a)
   end
 end


### PR DESCRIPTION
As of https://github.com/ITensor/GradedUnitRanges.jl/pull/11, `dag` is now defined in `GradedUnitRanges.dag`. I'm taking an approach with this package that we only define what is strictly necessary here, and offload as much as possible to other packages, so I'm deleting the definition from here (and anyway, the previous definition was a placeholder that was incorrect for symmetric tensors).

Also, I've properly defined `hasqns`, though probably we want to deprecate it and come up with a different name/concept that is defined in GradedUnitRanges.jl, maybe called `isgraded`. But that can be discussed later.