### PR TITLE
CompatHelper: bump compat for TensorAlgebra to 0.9, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorBase"
 uuid = "4795dd04-0d67-49bb-8f44-b89c448a1dc7"
-version = "0.5.18"
+version = "0.5.19"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]
@@ -18,5 +18,5 @@ Accessors = "0.1.39"
 ConstructionBase = "1.6"
 NamedDimsArrays = "0.14, 0.15"
 Random = "1.10"
-TensorAlgebra = "0.3, 0.4, 0.5, 0.6, 0.7, 0.8"
+TensorAlgebra = "0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9"
 julia = "1.10"


### PR DESCRIPTION
This pull request changes the compat entry for the `TensorAlgebra` package from `0.3, 0.4, 0.5, 0.6, 0.7, 0.8` to `0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.