### PR TITLE
Add `dimnametype` method for `AbstractITensor`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,10 @@ NamedDimsArrays = "60cbd0c0-df58-4cb7-918c-6f5607b73fde"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 TensorAlgebra = "68bd88dc-f39d-4e12-b2ca-f046b68fcc6a"
 
+[sources.NamedDimsArrays]
+rev = "mf/dimnametype"
+url = "https://github.com/ITensor/NamedDimsArrays.jl"
+
 [compat]
 Accessors = "0.1.39"
 ConstructionBase = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorBase"
 uuid = "4795dd04-0d67-49bb-8f44-b89c448a1dc7"
-version = "0.5.19"
+version = "0.5.20"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/Project.toml
+++ b/Project.toml
@@ -13,10 +13,6 @@ NamedDimsArrays = "60cbd0c0-df58-4cb7-918c-6f5607b73fde"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 TensorAlgebra = "68bd88dc-f39d-4e12-b2ca-f046b68fcc6a"
 
-[sources.NamedDimsArrays]
-rev = "mf/dimnametype"
-url = "https://github.com/ITensor/NamedDimsArrays.jl"
-
 [compat]
 Accessors = "0.1.39"
 ConstructionBase = "1.6"

--- a/src/abstractitensor.jl
+++ b/src/abstractitensor.jl
@@ -1,9 +1,10 @@
 using NamedDimsArrays: NamedDimsArrays, AbstractNamedDimsArray, LittleSet, NamedDimsArray,
-    denamed, dimnames, inds, mapinds
+    denamed, dimnames, dimnametype, inds, mapinds
 
 abstract type AbstractITensor <: AbstractNamedDimsArray{Any, Any} end
 
 NamedDimsArrays.nameddimsconstructor(::Type{<:IndexName}) = ITensor
+NamedDimsArrays.dimnametype(::Type{<:AbstractITensor}) = IndexName
 
 Base.ndims(::Type{<:AbstractITensor}) = Any
 

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -1,7 +1,7 @@
 using ITensorBase: ITensorBase, ITensor, Index, IndexName, gettag, hastag, plev, prime,
     setplev, settag, tags, unsettag
 using LinearAlgebra: factorize
-using NamedDimsArrays: dename, denamed, inds, mapinds, name, named
+using NamedDimsArrays: dename, denamed, dimnametype, inds, mapinds, name, named
 using Test: @test, @test_broken, @test_throws, @testset
 
 const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
@@ -107,6 +107,14 @@ const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
         @test a == b
         @test denamed(a) == dename(b, (i, j, k))
         @test denamed(a) == permutedims(denamed(b), (2, 3, 1))
+    end
+    @testset "dimnametype" begin
+        i, j = Index.((2, 3))
+        a = randn(Float64, i, j)
+        @test a isa ITensor
+        @test dimnametype(a) === IndexName
+        @test dimnametype(typeof(a)) === IndexName
+        @test dimnametype(ITensor) === IndexName
     end
     @testset "show" begin
         id = rand(UInt64)


### PR DESCRIPTION
## Summary

This PR adds the `NamedDimsArrays.dimnametype` method (introduced in
https://github.com/ITensor/NamedDimsArrays.jl/pull/224) for
`AbstractITensor`, returning `IndexName`.