### PR TITLE
Drop the AbstractArray supertype from AbstractITensor

### DIFF
--- a/src/abstractitensor.jl
+++ b/src/abstractitensor.jl
@@ -9,11 +9,12 @@ using TypeParameterAccessors: unspecify_type_parameters
 # https://github.com/mcabbott/NamedPlus.jl
 # https://pytorch.org/docs/stable/named_tensor.html
 
-abstract type AbstractITensor{DimName} <: AbstractArray{Any, Any} end
+abstract type AbstractITensor{DimName} end
 
-# Rank and element type live in the data, not the type. The `<: AbstractArray`
-# subtyping is kept for now to reuse generic array functionality, with `Any` for
-# both parameters since neither is fixed by the type.
+# Rank and element type live in the data, not the type, so the type-level `ndims`
+# is `Any` (like `eltype(Array)`). `AbstractITensor` is not an `AbstractArray`: the
+# array-like surface it needs (indexing, broadcasting, arithmetic, iteration) is
+# supplied directly below rather than inherited.
 Base.ndims(::Type{<:AbstractITensor}) = Any
 
 dimnames(a::AbstractITensor) = throw(MethodError(dimnames, a))
@@ -53,15 +54,15 @@ denamed(a::AbstractITensor, inds) = denamed(aligneddims(a, inds))
 dename(a::AbstractITensor, inds) = denamed(aligndims(a, inds))
 
 # Output the named axes/indices of the named dims array.
-inds(a::AbstractArray) = LittleSet(named.(axes(denamed(a)), dimnames(a)))
-inds(a::AbstractArray, dim::Int) = inds(a)[dim]
+inds(a::AbstractITensor) = LittleSet(named.(axes(denamed(a)), dimnames(a)))
+inds(a::AbstractITensor, dim::Int) = inds(a)[dim]
 
 isnamed(::Type{<:AbstractITensor}) = true
 
-function dim(a::AbstractArray, n)
+function dim(a::AbstractITensor, n)
     return findfirst(==(name(n)), dimnames(a))
 end
-dims(a::AbstractArray, ns) = Base.Fix1(dim, a).(ns)
+dims(a::AbstractITensor, ns) = Base.Fix1(dim, a).(ns)
 
 dimname_isequal(x) = Base.Fix1(dimname_isequal, x)
 dimname_isequal(x, y) = isequal(x, y)
@@ -80,7 +81,7 @@ dimname_isequal(r1, r2::AbstractNamedUnitRange) = r1 == name(r2)
 dimname_isequal(r1::AbstractNamedUnitRange, r2::Name) = name(r1) == name(r2)
 dimname_isequal(r1::Name, r2::AbstractNamedUnitRange) = name(r1) == name(r2)
 
-function to_inds(a::AbstractArray, dims)
+function to_inds(a::AbstractITensor, dims)
     is = Base.Fix1(dim, a).(name.(dims))
     return Base.Fix1(inds, a).(is)
 end
@@ -157,6 +158,11 @@ function checked_indexin(x::AbstractUnitRange, y::AbstractUnitRange)
 end
 
 Base.copy(a::AbstractITensor) = nameddimsof(a, copy(denamed(a)))
+Base.zero(a::AbstractITensor) = nameddimsof(a, zero(denamed(a)))
+
+# `CartesianIndices` of a named tensor is the parent's, via the named axes (as the
+# `AbstractArray` fallback did through `axes`).
+Base.CartesianIndices(a::AbstractITensor) = CartesianIndices(axes(a))
 
 # Forward `conj` to the underlying so that graded axes flip their sector arrows.
 # The default `AbstractArray` fallback would broadcast `conj` over elements without
@@ -169,6 +175,19 @@ Base.conj(a::AbstractITensor) = nameddimsof(a, conj(denamed(a)))
 function LinearAlgebra.normalize(a::AbstractITensor, p::Real = 2)
     return a / LinearAlgebra.norm(a, p)
 end
+function LinearAlgebra.normalize!(a::AbstractITensor, p::Real = 2)
+    LinearAlgebra.normalize!(denamed(a), p)
+    return a
+end
+
+# Elementwise and scalar arithmetic. `AbstractArray` routes these through
+# broadcasting; supply them directly now that the supertype is gone.
+Base.:+(a1::AbstractITensor, a2::AbstractITensor) = a1 .+ a2
+Base.:-(a1::AbstractITensor, a2::AbstractITensor) = a1 .- a2
+Base.:-(a::AbstractITensor) = broadcast(-, a)
+Base.:*(a::AbstractITensor, x::Number) = a .* x
+Base.:*(x::Number, a::AbstractITensor) = x .* a
+Base.:/(a::AbstractITensor, x::Number) = a ./ x
 
 # Forward `Random.randn!` / `Random.rand!` to the concrete storage so they
 # see the runtime eltype.
@@ -286,6 +305,26 @@ function Base.similar(a::AbstractArray, elt::Type, inds::LittleSet)
     return similar_nameddims(a, elt, inds)
 end
 
+# Same entry points with a named-tensor prototype. An `AbstractITensor` is no longer
+# an `AbstractArray`, so the methods above (which build a named tensor from a plain
+# array prototype) no longer cover it.
+function Base.similar(
+        a::AbstractITensor,
+        inds::Tuple{AbstractNamedUnitRange, Vararg{AbstractNamedUnitRange}}
+    )
+    return similar(a, eltype(a), inds)
+end
+function Base.similar(
+        a::AbstractITensor, elt::Type,
+        inds::Tuple{AbstractNamedUnitRange, Vararg{AbstractNamedUnitRange}}
+    )
+    return similar_nameddims(a, elt, inds)
+end
+Base.similar(a::AbstractITensor, inds::LittleSet) = similar_nameddims(a, eltype(a), inds)
+function Base.similar(a::AbstractITensor, elt::Type, inds::LittleSet)
+    return similar_nameddims(a, elt, inds)
+end
+
 function setinds(a::AbstractITensor, inds)
     return nameddimsconstructorof(a)(denamed(a), inds)
 end
@@ -319,6 +358,18 @@ Base.isempty(a::AbstractITensor) = isempty(denamed(a))
 # isn't known at compile time, like for the ITensor type.
 Base.IndexStyle(a::AbstractITensor) = IndexStyle(denamed(a))
 Base.eachindex(a::AbstractITensor) = eachindex(denamed(a))
+
+# Iteration, keys, and pairs forward to the parent (these were previously inherited
+# from `AbstractArray`).
+Base.iterate(a::AbstractITensor, state...) = iterate(denamed(a), state...)
+Base.keys(a::AbstractITensor) = keys(denamed(a))
+Base.pairs(a::AbstractITensor) = pairs(denamed(a))
+
+# Multi-argument `eachindex` dispatches on the named index style, as the
+# `AbstractArray` version did.
+function Base.eachindex(a1::AbstractITensor, a_rest::AbstractITensor...)
+    return eachindex(IndexStyle(a1, a_rest...), a1, a_rest...)
+end
 
 # Cartesian indices with names attached.
 struct NamedIndexCartesian <: IndexStyle end
@@ -387,7 +438,21 @@ function denamed(I::NamedDimsCartesianIndices)
     return CartesianIndices(denamed.(I.indices))
 end
 
-function Base.eachindex(::NamedIndexCartesian, a1::AbstractArray, a_rest::AbstractArray...)
+# Iterating yields `NamedDimsCartesianIndex`es. The generic `AbstractITensor`
+# iteration forwards to `denamed`, which here is a plain `CartesianIndices`, so
+# convert each parent index back through `getindex`.
+function Base.iterate(I::NamedDimsCartesianIndices, state...)
+    y = iterate(denamed(I), state...)
+    isnothing(y) && return nothing
+    cartesian, next_state = y
+    return I[Tuple(cartesian)...], next_state
+end
+
+function Base.eachindex(
+        ::NamedIndexCartesian,
+        a1::AbstractITensor,
+        a_rest::AbstractITensor...
+    )
     all(a -> issetequal(inds(a1), inds(a)), a_rest) ||
         throw(NameMismatch("Dimension name mismatch $(inds.((a1, a_rest...)))."))
     # TODO: Check the shapes match.
@@ -407,6 +472,12 @@ end
 function Base.:(==)(a1::AbstractITensor, a2::AbstractITensor)
     (inds(a1) == inds(a2)) || return false
     return denamed(a1) == denamed(a2, inds(a1))
+end
+
+# Base version ignores dimension names.
+function Base.isapprox(a1::AbstractITensor, a2::AbstractITensor; kwargs...)
+    (inds(a1) == inds(a2)) || return false
+    return isapprox(denamed(a1), denamed(a2, inds(a1)); kwargs...)
 end
 
 # Generalization of `Base.sort` to Tuples for Julia v1.10 compatibility.
@@ -641,7 +712,7 @@ function Base.view(a::AbstractITensor, I::ViewIndex...)
     return view_nameddims(a, I...)
 end
 
-function getindex_nameddims(a::AbstractArray, I...)
+function getindex_nameddims(a::AbstractITensor, I...)
     return copy(view(a, I...))
 end
 
@@ -686,7 +757,7 @@ end
 
 # Permute/align dimensions
 
-function aligndims(a::AbstractArray, dims)
+function aligndims(a::AbstractITensor, dims)
     new_dimnames = name.(dims)
     perm = Tuple(getperm(dimnames(a), new_dimnames))
     isperm(perm) || throw(
@@ -697,7 +768,7 @@ function aligndims(a::AbstractArray, dims)
     return nameddimsconstructorof(a)(permutedims(denamed(a), perm), new_dimnames)
 end
 
-function aligneddims(a::AbstractArray, dims)
+function aligneddims(a::AbstractITensor, dims)
     new_dimnames = name.(dims)
     perm = getperm(dimnames(a), new_dimnames)
     isperm(perm) || throw(

--- a/src/abstractnamedunitrange.jl
+++ b/src/abstractnamedunitrange.jl
@@ -97,13 +97,13 @@ denamed(c::NamedColon) = Colon()
 name(c::NamedColon) = c.name
 named(::Colon, name) = NamedColon(name)
 
-struct FirstIndex{Arr <: AbstractArray, Dim}
+struct FirstIndex{Arr, Dim}
     array::Arr
     dim::Dim
 end
 Base.to_index(i::FirstIndex) = Int(first(axes(i.array, i.dim)))
 
-struct LastIndex{Arr <: AbstractArray, Dim}
+struct LastIndex{Arr, Dim}
     array::Arr
     dim::Dim
 end

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -19,6 +19,10 @@ function BC.BroadcastStyle(arraytype::Type{<:AbstractITensor})
     return ITensorStyle{ndims(arraytype), nameddimsconstructorof(arraytype)}()
 end
 
+# An `AbstractITensor` broadcasts as itself (previously inherited from
+# `AbstractArray`); without this the default `broadcastable` wraps it in a `Ref`.
+BC.broadcastable(a::AbstractITensor) = a
+
 function BC.combine_axes(
         a1::AbstractITensor, a_rest::AbstractITensor...
     )
@@ -95,7 +99,7 @@ end
 set_check_broadcast_shape(ax1::Tuple{}, ax2::Tuple{}) = nothing
 
 broadcasted_denamed(x::Number, inds) = x
-broadcasted_denamed(a::AbstractArray, inds) = denamed(a, inds)
+broadcasted_denamed(a::AbstractITensor, inds) = denamed(a, inds)
 function broadcasted_denamed(bc::Broadcasted, inds)
     return broadcasted(bc.f, Base.Fix2(broadcasted_denamed, inds).(bc.args)...)
 end
@@ -142,7 +146,7 @@ function Base.copy(bc::Broadcasted{<:AbstractITensorStyle})
     return nameddimstype(bc.style)(dest_denamed, inds_dest)
 end
 
-function Base.copyto!(dest::AbstractArray, bc::Broadcasted{<:AbstractITensorStyle})
+function Base.copyto!(dest::AbstractITensor, bc::Broadcasted{<:AbstractITensorStyle})
     dest_denamed = denamed(dest)
     inds_dest = inds(dest)
     bc_denamed = broadcasted_denamed(bc, inds_dest)

--- a/src/tensoralgebra.jl
+++ b/src/tensoralgebra.jl
@@ -6,7 +6,7 @@ using TupleTools: TupleTools
 dimnames_setdiff(s1, s2) = setdiff(s1, s2)
 
 Base.:*(a1::AbstractITensor, a2::AbstractITensor) = mul_nameddims(a1, a2)
-function mul_nameddims(a1::AbstractArray, a2::AbstractArray)
+function mul_nameddims(a1::AbstractITensor, a2::AbstractITensor)
     a_dest, dimnames_dest = TA.contract(
         denamed(a1), dimnames(a1), denamed(a2), dimnames(a2)
     )
@@ -30,8 +30,8 @@ function Base.:*(
     return mul_nameddims(a1, a2, a3, a_rest...)
 end
 function mul_nameddims(
-        a1::AbstractArray, a2::AbstractArray,
-        a3::AbstractArray, a_rest::AbstractArray...
+        a1::AbstractITensor, a2::AbstractITensor,
+        a3::AbstractITensor, a_rest::AbstractITensor...
     )
     return *(*(a1, a2), a3, a_rest...)
 end
@@ -44,8 +44,8 @@ function LA.mul!(
     return mul!_nameddims(a_dest, a1, a2, α, β)
 end
 function mul!_nameddims(
-        a_dest::AbstractArray,
-        a1::AbstractArray, a2::AbstractArray,
+        a_dest::AbstractITensor,
+        a1::AbstractITensor, a2::AbstractITensor,
         α::Number, β::Number
     )
     TA.contractadd!(
@@ -64,8 +64,8 @@ function LA.mul!(
     return mul!_nameddims(a_dest, a1, a2)
 end
 function mul!_nameddims(
-        a_dest::AbstractArray,
-        a1::AbstractArray, a2::AbstractArray
+        a_dest::AbstractITensor,
+        a1::AbstractITensor, a2::AbstractITensor
     )
     TA.contract!(
         denamed(a_dest), dimnames(a_dest),
@@ -78,7 +78,7 @@ end
 function TA.blockedperm(na::AbstractITensor, nameddim_blocks::Tuple...)
     return blockedperm_nameddims(na, nameddim_blocks...)
 end
-function blockedperm_nameddims(a::AbstractArray, nameddim_blocks::Tuple...)
+function blockedperm_nameddims(a::AbstractITensor, nameddim_blocks::Tuple...)
     dimname_blocks = map(group -> name.(group), nameddim_blocks)
     dimnames_a = dimnames(a)
     perms = map(dimname_blocks) do dimname_block
@@ -95,7 +95,7 @@ end
 function TA.matricize(a::AbstractITensor, fusions::Vararg{Pair, 2})
     return matricize_nameddims(a, fusions...)
 end
-function matricize_nameddims(na::AbstractArray, fusions::Vararg{Pair, 2})
+function matricize_nameddims(na::AbstractITensor, fusions::Vararg{Pair, 2})
     dimnames_fuse = map(group -> name.(group), first.(fusions))
     dimnames_fused = last.(fusions)
     if sum(length, dimnames_fuse) < ndims(na)
@@ -116,7 +116,7 @@ end
 function TA.unmatricize(na::AbstractITensor, splitters::Vararg{Pair, 2})
     return unmatricize_nameddims(na, splitters...)
 end
-function unmatricize_nameddims(na::AbstractArray, splitters::Vararg{Pair, 2})
+function unmatricize_nameddims(na::AbstractITensor, splitters::Vararg{Pair, 2})
     splitters = name.(first.(splitters)) .=> last.(splitters)
     split_namedlengths = last.(splitters)
     splitters_denamed = map(splitters) do splitter
@@ -186,7 +186,7 @@ for f in [
             )
         end
         function $f_nameddims(
-                a::AbstractArray, dimnames_codomain, dimnames_domain; kwargs...
+                a::AbstractITensor, dimnames_codomain, dimnames_domain; kwargs...
             )
             codomain = name.(dimnames_codomain)
             domain = name.(dimnames_domain)
@@ -205,7 +205,7 @@ for f in [
                 a, dimnames_codomain; translate_factorization_kwargs(TA.$f, kwargs)...
             )
         end
-        function $f_nameddims(a::AbstractArray, dimnames_codomain; kwargs...)
+        function $f_nameddims(a::AbstractITensor, dimnames_codomain; kwargs...)
             codomain = name.(dimnames_codomain)
             domain = dimnames_setdiff(dimnames(a), codomain)
             return TA.$f(a, codomain, domain; kwargs...)
@@ -234,7 +234,7 @@ function TA.svd(
     return svd_nameddims(a, dimnames_codomain, dimnames_domain; kwargs...)
 end
 function svd_nameddims(
-        a::AbstractArray, dimnames_codomain, dimnames_domain; kwargs...
+        a::AbstractITensor, dimnames_codomain, dimnames_domain; kwargs...
     )
     codomain = name.(dimnames_codomain)
     domain = name.(dimnames_domain)
@@ -272,7 +272,7 @@ function TA.svdvals(
     return svdvals_nameddims(a, dimnames_codomain, dimnames_domain; kwargs...)
 end
 function svdvals_nameddims(
-        a::AbstractArray, dimnames_codomain, dimnames_domain; kwargs...
+        a::AbstractITensor, dimnames_codomain, dimnames_domain; kwargs...
     )
     return TA.svdvals(
         denamed(a),
@@ -286,7 +286,7 @@ end
 function TA.svdvals(a::AbstractITensor, dimnames_codomain; kwargs...)
     return svdvals_nameddims(a, dimnames_codomain; kwargs...)
 end
-function svdvals_nameddims(a::AbstractArray, dimnames_codomain; kwargs...)
+function svdvals_nameddims(a::AbstractITensor, dimnames_codomain; kwargs...)
     codomain = name.(dimnames_codomain)
     domain = dimnames_setdiff(dimnames(a), codomain)
     return TA.svdvals(a, codomain, domain; kwargs...)
@@ -302,7 +302,7 @@ function TA.eigen(
     return eigen_nameddims(a, dimnames_codomain, dimnames_domain; kwargs...)
 end
 function eigen_nameddims(
-        a::AbstractArray, dimnames_codomain, dimnames_domain; kwargs...
+        a::AbstractITensor, dimnames_codomain, dimnames_domain; kwargs...
     )
     codomain = name.(dimnames_codomain)
     domain = name.(dimnames_domain)
@@ -327,7 +327,7 @@ function TA.eigvals(
     return eigvals_nameddims(a, dimnames_codomain, dimnames_domain; kwargs...)
 end
 function eigvals_nameddims(
-        a::AbstractArray, dimnames_codomain, dimnames_domain; kwargs...
+        a::AbstractITensor, dimnames_codomain, dimnames_domain; kwargs...
     )
     codomain = name.(dimnames_codomain)
     domain = name.(dimnames_domain)
@@ -344,7 +344,7 @@ function TA.left_null(
     return left_null_nameddims(a, dimnames_codomain, dimnames_domain; kwargs...)
 end
 function left_null_nameddims(
-        a::AbstractArray, dimnames_codomain, dimnames_domain; kwargs...
+        a::AbstractITensor, dimnames_codomain, dimnames_domain; kwargs...
     )
     codomain = name.(dimnames_codomain)
     domain = name.(dimnames_domain)
@@ -369,7 +369,7 @@ function TA.right_null(
     return right_null_nameddims(a, dimnames_codomain, dimnames_domain; kwargs...)
 end
 function right_null_nameddims(
-        a::AbstractArray, dimnames_codomain, dimnames_domain; kwargs...
+        a::AbstractITensor, dimnames_codomain, dimnames_domain; kwargs...
     )
     codomain = name.(dimnames_codomain)
     domain = name.(dimnames_domain)
@@ -382,7 +382,7 @@ end
 function TA.right_null(a::AbstractITensor, dimnames_codomain; kwargs...)
     return right_null_nameddims(a, dimnames_codomain; kwargs...)
 end
-function right_null_nameddims(a::AbstractArray, dimnames_codomain; kwargs...)
+function right_null_nameddims(a::AbstractITensor, dimnames_codomain; kwargs...)
     codomain = name.(dimnames_codomain)
     domain = dimnames_setdiff(dimnames(a), codomain)
     return TA.right_null(a, codomain, domain; kwargs...)
@@ -426,7 +426,7 @@ function TA.gram_eigh_full(
     return gram_eigh_full_nameddims(a, dimnames_codomain, dimnames_domain; kwargs...)
 end
 function gram_eigh_full_nameddims(
-        a::AbstractArray, dimnames_codomain, dimnames_domain; kwargs...
+        a::AbstractITensor, dimnames_codomain, dimnames_domain; kwargs...
     )
     codomain = name.(dimnames_codomain)
     domain = name.(dimnames_domain)
@@ -480,7 +480,7 @@ function TA.gram_eigh_full_with_pinv(
     )
 end
 function gram_eigh_full_with_pinv_nameddims(
-        a::AbstractArray, dimnames_codomain, dimnames_domain; kwargs...
+        a::AbstractITensor, dimnames_codomain, dimnames_domain; kwargs...
     )
     codomain = name.(dimnames_codomain)
     domain = name.(dimnames_domain)
@@ -527,7 +527,7 @@ function Base.one(
     return one_nameddims(a, dimnames_codomain, dimnames_domain)
 end
 function one_nameddims(
-        a::AbstractArray, dimnames_codomain, dimnames_domain
+        a::AbstractITensor, dimnames_codomain, dimnames_domain
     )
     codomain = name.(dimnames_codomain)
     domain = name.(dimnames_domain)
@@ -552,7 +552,7 @@ for f in MATRIX_FUNCTIONS
             return $f_nameddims(a, dimnames_codomain, dimnames_domain; kwargs...)
         end
         function $f_nameddims(
-                a::AbstractArray, dimnames_codomain, dimnames_domain; kwargs...
+                a::AbstractITensor, dimnames_codomain, dimnames_domain; kwargs...
             )
             codomain = name.(dimnames_codomain)
             domain = name.(dimnames_domain)


### PR DESCRIPTION
## Summary

`AbstractITensor` is now a standalone abstract type rather than `<: AbstractArray{Any, Any}`. The array-like surface it relied on is supplied directly instead of inherited: `broadcastable` (feeding the existing `ITensorStyle`), elementwise and scalar arithmetic (`+`, `-`, `*`, `/`), iteration, `keys`/`pairs`, `CartesianIndices`, `zero`, `isapprox`, and `normalize!`.

The named-tensor verbs that were written on `::AbstractArray` only to ride the subtyping now dispatch on `::AbstractITensor`, which is what their bodies already required (they call `denamed`/`dimnames`): `inds`, `dim`, `dims`, `to_inds`, `aligndims`, `aligneddims`, and the contraction and factorization `*_nameddims` helpers. The methods that build a named tensor from a plain array stay on `::AbstractArray`.