### PR TITLE
Drop the AbstractNamedInteger <: Integer subtyping

### DIFF
--- a/ext/ITensorBaseBlockArraysExt/ITensorBaseBlockArraysExt.jl
+++ b/ext/ITensorBaseBlockArraysExt/ITensorBaseBlockArraysExt.jl
@@ -5,9 +5,9 @@ using ITensorBase: AbstractITensor, AbstractNamedInteger, AbstractNamedUnitRange
     getindex_named, view_nameddims
 
 # The first parameter of `AbstractNamedUnitRange` is its element type, an
-# `AbstractNamedInteger`, which is itself no longer an `Integer` subtype. These
-# methods disambiguate named-range block indexing from `BlockArrays`' generic
-# `AbstractArray` block-indexing methods.
+# `AbstractNamedInteger`, which is not an `Integer`. These methods disambiguate
+# named-range block indexing from `BlockArrays`' generic `AbstractArray`
+# block-indexing methods.
 function Base.getindex(r::AbstractNamedUnitRange{<:AbstractNamedInteger}, I::Block{1})
     # TODO: Use `Derive.@interface NamedArrayInterface() r[I]` instead.
     return getindex_named(r, I)

--- a/ext/ITensorBaseBlockArraysExt/ITensorBaseBlockArraysExt.jl
+++ b/ext/ITensorBaseBlockArraysExt/ITensorBaseBlockArraysExt.jl
@@ -4,9 +4,10 @@ using BlockArrays: Block, BlockRange
 using ITensorBase: AbstractITensor, AbstractNamedInteger, AbstractNamedUnitRange,
     getindex_named, view_nameddims
 
-# The first parameter of `AbstractNamedUnitRange` is the element type, which is an
-# `AbstractNamedInteger` (no longer an `Integer`). The constraint keeps these
-# disambiguating from `BlockArrays`' generic `AbstractArray` block-indexing methods.
+# The first parameter of `AbstractNamedUnitRange` is its element type, an
+# `AbstractNamedInteger`, which is itself no longer an `Integer` subtype. These
+# methods disambiguate named-range block indexing from `BlockArrays`' generic
+# `AbstractArray` block-indexing methods.
 function Base.getindex(r::AbstractNamedUnitRange{<:AbstractNamedInteger}, I::Block{1})
     # TODO: Use `Derive.@interface NamedArrayInterface() r[I]` instead.
     return getindex_named(r, I)

--- a/ext/ITensorBaseBlockArraysExt/ITensorBaseBlockArraysExt.jl
+++ b/ext/ITensorBaseBlockArraysExt/ITensorBaseBlockArraysExt.jl
@@ -1,14 +1,18 @@
 module ITensorBaseBlockArraysExt
 using ArrayLayouts: ArrayLayouts
 using BlockArrays: Block, BlockRange
-using ITensorBase: AbstractITensor, AbstractNamedUnitRange, getindex_named, view_nameddims
+using ITensorBase: AbstractITensor, AbstractNamedInteger, AbstractNamedUnitRange,
+    getindex_named, view_nameddims
 
-function Base.getindex(r::AbstractNamedUnitRange{<:Integer}, I::Block{1})
+# The first parameter of `AbstractNamedUnitRange` is the element type, which is an
+# `AbstractNamedInteger` (no longer an `Integer`). The constraint keeps these
+# disambiguating from `BlockArrays`' generic `AbstractArray` block-indexing methods.
+function Base.getindex(r::AbstractNamedUnitRange{<:AbstractNamedInteger}, I::Block{1})
     # TODO: Use `Derive.@interface NamedArrayInterface() r[I]` instead.
     return getindex_named(r, I)
 end
 
-function Base.getindex(r::AbstractNamedUnitRange{<:Integer}, I::BlockRange{1})
+function Base.getindex(r::AbstractNamedUnitRange{<:AbstractNamedInteger}, I::BlockRange{1})
     # TODO: Use `Derive.@interface NamedArrayInterface() r[I]` instead.
     return getindex_named(r, I)
 end

--- a/src/abstractitensor.jl
+++ b/src/abstractitensor.jl
@@ -626,7 +626,9 @@ function Base.getindex(a::AbstractArray, I1::NamedViewIndex, Irest::NamedViewInd
     return copy(view(a, I1, Irest...))
 end
 # Disambiguate from `Base.getindex(A::Array, I::AbstractUnitRange{<:Integer})`.
-function Base.getindex(a::Array, I1::AbstractNamedUnitRange{<:Integer})
+# The element type of a named unit range is an `AbstractNamedInteger` (no longer an
+# `Integer`).
+function Base.getindex(a::Array, I1::AbstractNamedUnitRange{<:AbstractNamedInteger})
     return copy(view(a, I1))
 end
 function Base.view(a::AbstractArray, I1::NamedViewIndex, Irest::NamedViewIndex...)

--- a/src/abstractitensor.jl
+++ b/src/abstractitensor.jl
@@ -626,8 +626,8 @@ function Base.getindex(a::AbstractArray, I1::NamedViewIndex, Irest::NamedViewInd
     return copy(view(a, I1, Irest...))
 end
 # Disambiguate from `Base.getindex(A::Array, I::AbstractUnitRange{<:Integer})`.
-# A named unit range's element type is an `AbstractNamedInteger`, which is itself no
-# longer an `Integer` subtype, so the constraint names `AbstractNamedInteger`.
+# The element type of a named unit range is an `AbstractNamedInteger`, which is not
+# an `Integer`.
 function Base.getindex(a::Array, I1::AbstractNamedUnitRange{<:AbstractNamedInteger})
     return copy(view(a, I1))
 end

--- a/src/abstractitensor.jl
+++ b/src/abstractitensor.jl
@@ -626,8 +626,8 @@ function Base.getindex(a::AbstractArray, I1::NamedViewIndex, Irest::NamedViewInd
     return copy(view(a, I1, Irest...))
 end
 # Disambiguate from `Base.getindex(A::Array, I::AbstractUnitRange{<:Integer})`.
-# The element type of a named unit range is an `AbstractNamedInteger` (no longer an
-# `Integer`).
+# A named unit range's element type is an `AbstractNamedInteger`, which is itself no
+# longer an `Integer` subtype, so the constraint names `AbstractNamedInteger`.
 function Base.getindex(a::Array, I1::AbstractNamedUnitRange{<:AbstractNamedInteger})
     return copy(view(a, I1))
 end

--- a/src/abstractnamedinteger.jl
+++ b/src/abstractnamedinteger.jl
@@ -148,8 +148,7 @@ function Base.string(i::AbstractNamedInteger; kwargs...)
 end
 
 (type::Type{<:Number})(i::AbstractNamedInteger) = type(denamed(i))
-# `<: Integer` previously supplied this; with `AbstractNamedInteger` standalone,
-# converting to a plain number drops the name and converts the value.
+# Converting to a plain number type converts the value and drops the name.
 function Base.convert(::Type{T}, i::AbstractNamedInteger) where {T <: Number}
     return convert(T, denamed(i))
 end

--- a/src/abstractnamedinteger.jl
+++ b/src/abstractnamedinteger.jl
@@ -147,12 +147,6 @@ function Base.string(i::AbstractNamedInteger; kwargs...)
     return "named($(string(denamed(i); kwargs...)), $(repr(name(i))))"
 end
 
-(type::Type{<:Number})(i::AbstractNamedInteger) = type(denamed(i))
-# Converting to a plain number type converts the value and drops the name.
-function Base.convert(::Type{T}, i::AbstractNamedInteger) where {T <: Number}
-    return convert(T, denamed(i))
-end
-
 struct NameMismatch <: Exception
     message::String
 end

--- a/src/abstractnamedinteger.jl
+++ b/src/abstractnamedinteger.jl
@@ -1,6 +1,10 @@
 using TypeParameterAccessors: unspecify_type_parameters
 
-abstract type AbstractNamedInteger{Value, Name} <: Integer end
+# A named integer is a tagged scalar, not a true `Integer`: mixed named/unnamed
+# arithmetic and operations like `i1 * i2` are not cleanly definable under the
+# `Integer` contract, and inherited `Integer` fallbacks risk silently dropping the
+# name. So it is standalone and supplies the integer-like surface it needs directly.
+abstract type AbstractNamedInteger{Value, Name} end
 
 # Minimal interface.
 denamed(i::AbstractNamedInteger) = throw(MethodError(dename, Tuple{typeof(i)}))
@@ -144,6 +148,11 @@ function Base.string(i::AbstractNamedInteger; kwargs...)
 end
 
 (type::Type{<:Number})(i::AbstractNamedInteger) = type(denamed(i))
+# `<: Integer` previously supplied this; with `AbstractNamedInteger` standalone,
+# converting to a plain number drops the name and converts the value.
+function Base.convert(::Type{T}, i::AbstractNamedInteger) where {T <: Number}
+    return convert(T, denamed(i))
+end
 
 struct NameMismatch <: Exception
     message::String

--- a/src/abstractnamedunitrange.jl
+++ b/src/abstractnamedunitrange.jl
@@ -86,13 +86,13 @@ struct FirstIndex{Arr, Dim}
     array::Arr
     dim::Dim
 end
-Base.to_index(i::FirstIndex) = Int(first(axes(i.array, i.dim)))
+Base.to_index(i::FirstIndex) = denamed(first(axes(i.array, i.dim)))
 
 struct LastIndex{Arr, Dim}
     array::Arr
     dim::Dim
 end
-Base.to_index(i::LastIndex) = Int(last(axes(i.array, i.dim)))
+Base.to_index(i::LastIndex) = denamed(last(axes(i.array, i.dim)))
 
 function Base.getindex(r::AbstractNamedUnitRange, I::FirstIndex)
     return first(r)

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -57,7 +57,7 @@ const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
                 Index(2; tags = ("X" => "Y",)),
                 Index(2; tags = "X" => "Y"),
             )
-            @test Int(length(i)) == 2
+            @test denamed(length(i)) == 2
             @test hastag(i, "X")
             @test gettag(i, "X") == "Y"
             @test plev(i) == 0
@@ -137,8 +137,8 @@ const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
         @test j ∈ inds(y)
         @test eltype(x) === elt
         @test eltype(y) === elt
-        @test Int.(Tuple(size(x))) == (2, 2)
-        @test Int.(Tuple(size(y))) == (2, 2)
+        @test denamed.(Tuple(size(x))) == (2, 2)
+        @test denamed.(Tuple(size(y))) == (2, 2)
 
         i = Index(2)
         j = Index(2)
@@ -146,8 +146,8 @@ const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
         for kwargs in ((; rtol = 1.0e-2), (; cutoff = 1.0e-2))
             x, y = factorize(a, (i,); kwargs...)
             @test a ≈ x * y
-            @test Int.(Tuple(size(x))) == (2, 1)
-            @test Int.(Tuple(size(y))) == (1, 2)
+            @test denamed.(Tuple(size(x))) == (2, 1)
+            @test denamed.(Tuple(size(y))) == (1, 2)
         end
     end
 end

--- a/test/test_namedinteger.jl
+++ b/test/test_namedinteger.jl
@@ -7,8 +7,4 @@ using Test: @test, @testset
     @test i isa AbstractNamedInteger
     @test denamed(i) ≡ 3
     @test name(i) ≡ :i
-    for type in (Int32, Int64, Float32, Float64)
-        @test type(i) ≡ type(3)
-        @test convert(type, i) ≡ type(3)
-    end
 end

--- a/test/test_tensoralgebra.jl
+++ b/test/test_tensoralgebra.jl
@@ -104,7 +104,7 @@ using Test: @test, @test_broken, @testset
         a = randn(elt, i, j, k, l)
         u, s, v = svd(a, (i, k), (j, l); trunc = (; maxrank = 2))
         @test u * s * v ≉ a
-        @test Int.(Tuple(size(s))) == (2, 2)
+        @test denamed.(Tuple(size(s))) == (2, 2)
     end
     @testset "left_null/right_null" begin
         dims = (2, 2, 2, 2)


### PR DESCRIPTION
## Summary

Makes `AbstractNamedInteger` a standalone abstract type instead of `<: Integer`. A named integer is a tagged scalar, not a true integer: operations like `i1 * i2` fuse names rather than multiply cleanly, mixed named and unnamed arithmetic has no well-defined meaning, and inherited `Integer` fallbacks risk silently dropping the name. The type keeps the explicit integer-like surface it actually needs (equality, hashing, the arithmetic it supports, ordering, `show`).

This also removes the named-to-plain-number conversion path (the `Number` constructor and `convert`) that let named and unnamed integers interoperate. That interoperation is what the standalone design deliberately drops, and a `convert` that silently discards the name is exactly the name loss being avoided. The one internal consumer, resolving `begin` and `end` to a plain index in `to_index`, now reads the underlying value with `denamed`, which is also how callers should get the plain integer from a named integer.

The element-type constraints that disambiguate named-range indexing (the `BlockArrays` `getindex` methods and the plain-`Array` indexing method) change from `{<:Integer}` to `{<:AbstractNamedInteger}`, since a named unit range's element type is a named integer, which is not an `Integer`.
