### PR TITLE
Remove FusedNames and error on ITensor length

### DIFF
--- a/src/abstractitensor.jl
+++ b/src/abstractitensor.jl
@@ -240,9 +240,8 @@ function Base.size(a::AbstractITensor)
     return length.(axes(a))
 end
 
-function Base.length(a::AbstractITensor)
-    return prod(size(a); init = 1)
-end
+# `length` is intentionally not defined: an ITensor's dimensions are named and
+# unordered, so there is no canonical linearization into `1:length`.
 
 # Circumvent issue when ndims isn't known at compile time.
 Base.axes(a::AbstractITensor, d) = axes(a)[d]

--- a/src/abstractnamedarray.jl
+++ b/src/abstractnamedarray.jl
@@ -48,6 +48,10 @@ getindex_named(a::AbstractArray, I...) = named(getindex(denamed(a), I...), name(
 Base.size(a::AbstractNamedArray) = map(s -> named(s, name(a)), size(denamed(a)))
 Base.axes(a::AbstractNamedArray) = map(s -> named(s, name(a)), axes(denamed(a)))
 Base.eachindex(a::AbstractNamedArray) = eachindex(denamed(a))
+# A named array carries a single name, so its length is that name attached to the
+# denamed length. No fusion is involved, unlike a multi-dim `AbstractITensor`, which
+# has no single name and so does not define `length`.
+Base.length(a::AbstractNamedArray) = named(length(denamed(a)), name(a))
 function Base.getindex(a::AbstractNamedArray{<:Any, <:Any, N}, I::Vararg{Int, N}) where {N}
     return getindex_named(a, I...)
 end

--- a/src/name.jl
+++ b/src/name.jl
@@ -53,27 +53,6 @@ function _parse_name(ex)
     end
 end
 
-# vcat that works with combinations of tuples
-# and vectors.
-generic_vcat(v1, v2) = vcat(v1, v2)
-generic_vcat(v1::Tuple, v2) = vcat([v1...], v2)
-generic_vcat(v1, v2::Tuple) = vcat(v1, [v2...])
-generic_vcat(v1::Tuple, v2::Tuple) = (v1..., v2...)
-
-struct FusedNames{Names} <: AbstractName
-    names::Names
-end
-fusednames(name1, name2) = FusedNames((name1, name2))
-function fusednames(name1::FusedNames, name2::FusedNames)
-    return FusedNames(generic_vcat(name1.names, name2.names))
-end
-fusednames(name1, name2::FusedNames) = fusednames(FusedNames((name1,)), name2)
-fusednames(name1::FusedNames, name2) = fusednames(name1, FusedNames((name2,)))
-
-function Base.:(==)(n1::FusedNames, n2::FusedNames)
-    return mapreduce(==, &, n1.names, n2.names)
-end
-
 struct NameMismatch <: Exception
     message::String
 end

--- a/src/named.jl
+++ b/src/named.jl
@@ -59,10 +59,6 @@ function Base.show(io::IO, i::Named)
 end
 
 # Integer interface, for the named-integer case `NamedInteger`.
-# TODO: Should `*` make a random name, or require defining a way to combine names?
-function Base.:*(i1::NamedInteger, i2::NamedInteger)
-    return named(denamed(i1) * denamed(i2), fusednames(name(i1), name(i2)))
-end
 Base.:-(i::NamedInteger) = setvalue(i, -denamed(i))
 
 ## TODO: Support this, we need to define `NamedFloat`, `NamedReal`, `NamedNumber`, etc.
@@ -72,13 +68,6 @@ Base.:-(i::NamedInteger) = setvalue(i, -denamed(i))
 ## function Base.:*(i1::NamedInteger, i2::Number)
 ##   return named(denamed(i1) * i2, name(i1))
 ## end
-
-# For the sake of generic code, the name is ignored.
-# Used in `AbstractArray` `Base.show`.
-# TODO: See if we can delete this.
-Base.:+(i1::Int, i2::NamedInteger) = i1 + denamed(i2)
-
-Base.:*(i1::Int, i2::NamedInteger) = named(i1 * denamed(i2), name(i2))
 
 Base.zero(i::NamedInteger) = setvalue(i, zero(denamed(i)))
 Base.one(i::NamedInteger) = setvalue(i, one(denamed(i)))

--- a/src/namedunitrange.jl
+++ b/src/namedunitrange.jl
@@ -40,7 +40,7 @@ Base.conj(r::NamedUnitRange) = named(conj(denamed(r)), name(r))
 # Unit range functionality.
 Base.first(r::NamedUnitRange) = named(first(denamed(r)), name(r))
 Base.last(r::NamedUnitRange) = named(last(denamed(r)), name(r))
-Base.length(r::NamedUnitRange) = named(length(denamed(r)), name(r))
+# `length` is inherited from the `AbstractNamedArray` generic (identical definition).
 Base.size(r::NamedUnitRange) = (named(length(denamed(r)), name(r)),)
 Base.axes(r::NamedUnitRange) = (named(only(axes(denamed(r))), name(r)),)
 Base.step(r::NamedUnitRange) = named(step(denamed(r)), name(r))

--- a/test/test_nameddims_basics.jl
+++ b/test/test_nameddims_basics.jl
@@ -1,9 +1,8 @@
 using Combinatorics: Combinatorics
 using ITensorBase: @names, AbstractITensor, ITensor, Name, NameMismatch,
     NamedDimsCartesianIndex, NamedDimsCartesianIndices, aligndims, aligneddims, apply,
-    dename, denamed, denamedtype, dim, dimnames, dimnametype, dims, fusednames, inds,
-    isnamed, mapinds, name, named, nameddims, namedoneto, product, replacedimnames,
-    replaceinds, setinds
+    dename, denamed, denamedtype, dim, dimnames, dimnametype, dims, inds, isnamed, mapinds,
+    name, named, nameddims, namedoneto, product, replacedimnames, replaceinds, setinds
 using LinearAlgebra: LinearAlgebra
 using Test: @test, @test_throws, @testset
 using VectorInterface: scalartype
@@ -230,7 +229,8 @@ end
         na[1, 1] = 11
         @test na[1, 1] == 11
         @test Tuple(size(na)) == (named(3, "i"), named(4, "j"))
-        @test length(na) == named(12, fusednames("i", "j"))
+        # An ITensor has named, unordered dims, so `length` (a linearization) errors.
+        @test_throws MethodError length(na)
         @test Tuple(axes(na)) == (named(1:3, "i"), named(1:4, "j"))
         @test randn(named.((3, 4), ("i", "j"))) isa ITensor
         @test na["i" => 1, "j" => 2] == a[1, 2]


### PR DESCRIPTION
## Summary

Removes `FusedNames` and the `Base.:*(::NamedInteger, ::NamedInteger)` method it backed. That product existed only to give `length` a name when multiplying a tensor's named dimension sizes, producing results like `named(12, fusednames("i", "j"))`.

`length` is now defined directly:

- An `AbstractNamedArray` carries a single name, so its `length` is that name on the denamed length, `named(length(denamed(a)), name(a))`, with no fusion. `NamedUnitRange` inherits this, and its identical override is removed.
- An `AbstractITensor` has multiple, unordered named dimensions, so it has no single name to attach and no canonical linear order over its elements. Its `length` method is removed, so `length` of an ITensor now errors.

Also drops the now-unused `Base.:*(::Int, ::NamedInteger)` and `Base.:+(::Int, ::NamedInteger)`.