### PR TITLE
Clean up tensor reconstruction and the operator type

### DIFF
--- a/ext/ITensorBaseMooncakeExt/ITensorBaseMooncakeExt.jl
+++ b/ext/ITensorBaseMooncakeExt/ITensorBaseMooncakeExt.jl
@@ -1,8 +1,7 @@
 module ITensorBaseMooncakeExt
 
-using ITensorBase: AbstractITensor, NamedUnitRange, blockedperm_nameddims,
-    combine_nameddimsconstructors, dimnames, dimnames_setdiff, inds, name,
-    nameddimsconstructorof, to_inds, uniquename
+using ITensorBase: AbstractITensor, NamedUnitRange, blockedperm_nameddims, dimnames,
+    dimnames_setdiff, inds, name, to_inds, uniquename
 using Mooncake: Mooncake, @zero_derivative, DefaultCtx
 using TensorAlgebra: blockedperm
 
@@ -10,7 +9,6 @@ Mooncake.tangent_type(::Type{<:NamedUnitRange}) = Mooncake.NoTangent
 
 @zero_derivative DefaultCtx Tuple{typeof(blockedperm), AbstractITensor, Any, Any}
 @zero_derivative DefaultCtx Tuple{typeof(blockedperm_nameddims), Any, Any, Any}
-@zero_derivative DefaultCtx Tuple{typeof(combine_nameddimsconstructors), Any, Any}
 # `dimnames(::ITensor)` returns the stored names `Vector` directly, so its output
 # aliases a field, where `@zero_derivative` is documented to be incorrect. Let
 # Mooncake differentiate it through the underlying `getfield`, whose built-in rule
@@ -20,7 +18,6 @@ Mooncake.tangent_type(::Type{<:NamedUnitRange}) = Mooncake.NoTangent
 @zero_derivative DefaultCtx Tuple{typeof(inds), Any}
 @zero_derivative DefaultCtx Tuple{typeof(inds), Any, Any}
 @zero_derivative DefaultCtx Tuple{typeof(name), Any}
-@zero_derivative DefaultCtx Tuple{typeof(nameddimsconstructorof), Any}
 @zero_derivative DefaultCtx Tuple{typeof(uniquename), Any}
 @zero_derivative DefaultCtx Tuple{typeof(uniquename), Any, Any}
 @zero_derivative DefaultCtx Tuple{typeof(to_inds), Any, Any}

--- a/src/abstractitensor.jl
+++ b/src/abstractitensor.jl
@@ -94,48 +94,18 @@ end
 Construct a named dimensions array from an denamed array `a` and named dimensions `inds`.
 """
 function nameddims(a::AbstractArray, inds)
-    return nameddimsconstructor(a, inds)(a, inds)
+    return ITensor(a, inds)
 end
 
 #=
     nameddimsof(a::AbstractITensor, b::AbstractArray)
 
 Construct a named dimensions array with the dimension names of `a`
-and based on the type of `a` but with the data from `b`.
+and with the data from `b`.
 =#
 function nameddimsof(a::AbstractITensor, b::AbstractArray)
-    return nameddimsconstructorof(a)(b, dimnames(a))
+    return nameddims(b, dimnames(a))
 end
-
-# Interface inspired by
-# [ConstructionBase.constructorof](https://github.com/JuliaObjects/ConstructionBase.jl).
-nameddimsconstructorof(a::AbstractITensor) = nameddimsconstructorof(typeof(a))
-function nameddimsconstructorof(type::Type{<:AbstractITensor})
-    return Base.typename(type).wrapper
-end
-
-# Output a constructor for a named dims array (that should accept and denamed array and
-# a set of named dimensions/axes/indices) based on the dimension names.
-function nameddimsconstructor(a::AbstractArray, dims)
-    dimnames = name.(dims)
-    isempty(dimnames) && return ITensor
-    return mapreduce(nameddimsconstructor, combine_nameddimsconstructors, dimnames)
-end
-
-nameddimsconstructor(nameddim) = nameddimsconstructor(typeof(nameddim))
-# Can overload this to get custom named dims array wrapper
-# depending on the dimension name types, for example
-# output an `ITensor` if the dimension names are `IndexName`s.
-nameddimsconstructor(nameddimtype::Type) = ITensor
-function nameddimsconstructor(nameddimtype::Type{<:NamedUnitRange})
-    return nameddimsconstructor(nametype(nameddimtype))
-end
-function combine_nameddimsconstructors(
-        ::Type{<:AbstractITensor}, ::Type{<:AbstractITensor}
-    )
-    return ITensor
-end
-combine_nameddimsconstructors(::Type{T}, ::Type{T}) where {T <: AbstractITensor} = T
 
 # TODO: Move to `utils.jl` file.
 # TODO: Use `Base.indexin`?
@@ -263,7 +233,7 @@ Base.axes(a::AbstractITensor, dimname::Name) = axes(a, dim(a, dimname))
 Base.size(a::AbstractITensor, dimname::Name) = size(a, dim(a, dimname))
 
 function similar_nameddims(a::AbstractITensor, elt::Type, ax)
-    return nameddimsconstructorof(a)(
+    return nameddims(
         similar(denamed(a), elt, denamed.(Tuple(ax))),
         name.(ax)
     )
@@ -311,8 +281,8 @@ function Base.similar(
     )
     return similar_nameddims(a, elt, inds)
 end
-function setinds(a::AbstractITensor, inds)
-    return nameddimsconstructorof(a)(denamed(a), inds)
+function setdimnames(a::AbstractITensor, dimnames)
+    return nameddims(denamed(a), dimnames)
 end
 
 function replacedimnames(a::AbstractITensor, replacements::Pair...)
@@ -693,7 +663,7 @@ isscalarindex(I::Real) = true
 function view_nameddims(a::AbstractITensor, I...)
     nonscalar_dims = filter(dim -> !isscalarindex(I[dim]), ntuple(identity, ndims(a)))
     nonscalar_dimnames = map(dim -> dimnames(a, dim), nonscalar_dims)
-    return nameddimsconstructorof(a)(view(denamed(a), I...), nonscalar_dimnames)
+    return nameddims(view(denamed(a), I...), nonscalar_dimnames)
 end
 
 function Base.view(a::AbstractITensor, I::ViewIndex...)
@@ -724,7 +694,7 @@ function Base.setindex!(
         Irest::NamedViewIndex...
     )
     I = (I1, Irest...)
-    a[I...] = nameddimsconstructorof(a)(value, name.(I))
+    a[I...] = nameddims(value, name.(I))
     return a
 end
 function Base.setindex!(
@@ -753,7 +723,7 @@ function aligndims(a::AbstractITensor, dims)
             "Dimension name mismatch $(dimnames(a)), $(new_dimnames)."
         )
     )
-    return nameddimsconstructorof(a)(permutedims(denamed(a), perm), new_dimnames)
+    return nameddims(permutedims(denamed(a), perm), new_dimnames)
 end
 
 function aligneddims(a::AbstractITensor, dims)
@@ -764,7 +734,7 @@ function aligneddims(a::AbstractITensor, dims)
             "Dimension name mismatch $(dimnames(a)), $(new_dimnames)."
         )
     )
-    return nameddimsconstructorof(a)(
+    return nameddims(
         permuteddims(denamed(a), perm), new_dimnames
     )
 end

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -1,22 +1,21 @@
 using ..ITensorBase: AbstractITensor, ITensorBase, NamedUnitRange, dename, denamed, getperm,
-    inds, name, named, nameddimsconstructorof
+    inds, name, named, nameddims
 using Base.Broadcast: Broadcast as BC, Broadcasted, broadcast_shape, broadcasted,
     check_broadcast_shape, combine_axes
 using TensorAlgebra: TensorAlgebra as TA
 
 abstract type AbstractITensorStyle{N} <: BC.AbstractArrayStyle{N} end
 
-struct ITensorStyle{N, NDA} <: AbstractITensorStyle{N} end
-ITensorStyle(::Val{N}) where {N} = ITensorStyle{N, ITensor}()
-ITensorStyle{M}(::Val{N}) where {M, N} = ITensorStyle{N, ITensor}()
-ITensorStyle{M, NDA}(::Val{N}) where {M, N, NDA} = ITensorStyle{N, NDA}()
-
-function nameddimstype(style::ITensorStyle{<:Any, NDA}) where {NDA}
-    return NDA
-end
+# Both `ITensorStyle` and `ITensorOperatorStyle` are dynamically-ranked
+# (`ndims(::AbstractITensor) === Any`), so the rank parameter `N` is `Any`. The
+# `Val{N}` constructors below are required by `Base.Broadcast` for ranked styles;
+# they preserve the style and ignore the inferred rank.
+struct ITensorStyle{N} <: AbstractITensorStyle{N} end
+ITensorStyle(::Val{N}) where {N} = ITensorStyle{N}()
+ITensorStyle{M}(::Val{N}) where {M, N} = ITensorStyle{N}()
 
 function BC.BroadcastStyle(arraytype::Type{<:AbstractITensor})
-    return ITensorStyle{ndims(arraytype), nameddimsconstructorof(arraytype)}()
+    return ITensorStyle{ndims(arraytype)}()
 end
 
 # An `AbstractITensor` broadcasts as itself (previously inherited from
@@ -134,7 +133,7 @@ function Base.similar(bc::Broadcasted{<:AbstractITensorStyle}, elt::Type, ax)
     inds_a = name.(ax)
     bc_denamed = broadcasted_denamed(bc, inds_a)
     a_denamed = similar(bc_denamed, elt)
-    return nameddimstype(bc.style)(a_denamed, inds_a)
+    return nameddims(a_denamed, inds_a)
 end
 
 inds(bc::Broadcasted) = name.(axes(bc))
@@ -161,7 +160,7 @@ function Base.copy(bc::Broadcasted{<:AbstractITensorStyle})
         dest_denamed = similar(denamed_prototype(bc), eltype(lb), dest_axes)
         copyto!(dest_denamed, lb)
     end
-    return nameddimstype(bc.style)(dest_denamed, inds_dest)
+    return nameddims(dest_denamed, inds_dest)
 end
 
 function Base.copyto!(dest::AbstractITensor, bc::Broadcasted{<:AbstractITensorStyle})
@@ -177,4 +176,53 @@ function Base.copyto!(dest::AbstractITensor, bc::Broadcasted{<:AbstractITensorSt
         copyto!(dest_denamed, lb)
     end
     return dest
+end
+
+# Operator-preserving broadcasting.
+#
+# An `ITensorOperator` broadcasts as itself (it does not peel to its `state`), so
+# `op .+ op`, `2 .* op`, etc. carry the `ITensorOperatorStyle`. The style-combination
+# rules below enforce the input rules declaratively:
+#   - operator ⊗ operator → operator (preserved),
+#   - operator ⊗ scalar → operator (`2 .* op` stays an operator),
+#   - operator ⊗ non-operator tensor → error.
+# The `BroadcastStyle(::Type{<:ITensorOperator})` mapping and the operator-specific
+# `copy` / `similar` (which unwrap, delegate to `ITensorStyle`, then rewrap) live in
+# `itensoroperator.jl`, where `ITensorOperator` is defined. `*` (contraction) is
+# unchanged and still decays to `state`.
+
+struct ITensorOperatorStyle{N} <: AbstractITensorStyle{N} end
+ITensorOperatorStyle(::Val{N}) where {N} = ITensorOperatorStyle{N}()
+ITensorOperatorStyle{M}(::Val{N}) where {M, N} = ITensorOperatorStyle{N}()
+
+# operator ⊗ operator stays an operator.
+function BC.BroadcastStyle(
+        ::ITensorOperatorStyle{M},
+        ::ITensorOperatorStyle{N}
+    ) where {M, N}
+    return ITensorOperatorStyle{M}()
+end
+# operator ⊗ scalar (`DefaultArrayStyle{0}`, e.g. `2 .* op`) stays an operator.
+function BC.BroadcastStyle(
+        style::ITensorOperatorStyle, ::BC.DefaultArrayStyle{0}
+    )
+    return style
+end
+# operator ⊗ non-operator named tensor is type-nonsense and is rejected.
+function BC.BroadcastStyle(::ITensorOperatorStyle, ::ITensorStyle)
+    return throw(
+        ArgumentError(
+            "Cannot broadcast an `ITensorOperator` together with a non-operator " *
+                "tensor. Wrap the tensor as an operator first, or unwrap the " *
+                "operator with `state`."
+        )
+    )
+end
+
+# Reinterpret an operator-style `Broadcasted` under `ITensorStyle`, the broadcast
+# over the operators' states, so the shared `ITensorStyle` implementation runs (its
+# `broadcasted_denamed` already peels each operator operand to its `state` via
+# `denamed`).
+function statebroadcasted(bc::Broadcasted{<:ITensorOperatorStyle})
+    return Broadcasted{ITensorStyle{Any}}(bc.f, bc.args, bc.axes)
 end

--- a/src/itensoroperator.jl
+++ b/src/itensoroperator.jl
@@ -1,3 +1,4 @@
+using Base.Broadcast: Broadcast as BC, Broadcasted
 using OrderedCollections: OrderedDict
 using Random: Random
 
@@ -97,10 +98,38 @@ Base.iterate(b::Bijection) = iterate(b.domain_to_codomain)
 Base.iterate(b::Bijection, state) = iterate(b.domain_to_codomain, state)
 Base.length(b::Bijection) = length(b.domain_to_codomain)
 
-abstract type AbstractITensorOperator{DimName} <: AbstractITensor{DimName} end
+struct ITensorOperator{DimName, P <: AbstractITensor{DimName}, D, C} <:
+    AbstractITensor{DimName}
+    parent::P
+    dimnames_bijection::Bijection{D, C}
+end
 
 state(a::AbstractITensor) = a
-dimnames(a::AbstractITensorOperator) = dimnames(state(a))
+state(a::ITensorOperator) = a.parent
+Base.parent(a::ITensorOperator) = state(a)
+denamed(a::ITensorOperator) = denamed(state(a))
+dimnames(a::ITensorOperator) = dimnames(state(a))
+
+function ITensorOperator(a::AbstractITensor, codomainnames, domainnames)
+    return ITensorOperator(a, Bijection(domainnames, codomainnames))
+end
+
+parenttype(type::Type{<:ITensorOperator}) = fieldtype(type, :parent)
+statetype(type::Type{<:ITensorOperator}) = parenttype(type)
+
+function nameddimsof(a::ITensorOperator, b::AbstractArray)
+    return ITensorOperator(nameddimsof(state(a), b), a.dimnames_bijection)
+end
+
+codomainnames(a::ITensorOperator) = codomain(a.dimnames_bijection)
+domainnames(a::ITensorOperator) = domain(a.dimnames_bijection)
+
+function get_codomain_name(a::ITensorOperator, i)
+    return get(a.dimnames_bijection, i, i)
+end
+function get_domain_name(a::ITensorOperator, i)
+    return get(inverse(a.dimnames_bijection), i, i)
+end
 
 # TODO: Unify these two functions.
 function operator(a::AbstractArray, codomain, domain)
@@ -113,23 +142,64 @@ end
 
 # This helps preserve the ITensor type when multiplying,
 # for example when a ITensorOperator wraps an ITensor.
-Base.:*(a::AbstractITensorOperator, b::AbstractITensorOperator) = state(a) * state(b)
-Base.:*(a::AbstractITensorOperator, b::AbstractITensor) = state(a) * state(b)
-Base.:*(a::AbstractITensor, b::AbstractITensorOperator) = state(a) * state(b)
+Base.:*(a::ITensorOperator, b::ITensorOperator) = state(a) * state(b)
+Base.:*(a::ITensorOperator, b::AbstractITensor) = state(a) * state(b)
+Base.:*(a::AbstractITensor, b::ITensorOperator) = state(a) * state(b)
 
-# Broadcasting peels an operator to its `state` before the broadcast style is
-# computed. This covers the array operations that lower to broadcasting too (`+`,
-# `-`, scalar multiplication), and avoids the generic style path reading `ndims`
-# off the type, which throws for a dynamically-ranked parent such as an `ITensor`.
-# As a shortcut the result is a bare state, dropping the operator wrapper, matching
-# `*`; keeping it an operator (carrying the codomain/domain bijection) is future
-# work that first needs the mixed cases settled (`state + operator`, and
-# `operator + operator` where names match but the codomain/domain split does not).
-Base.broadcastable(a::AbstractITensorOperator) = state(a)
+# Operator-preserving broadcasting (the style struct and style-combination rules
+# live in `broadcast.jl`). An `ITensorOperator` broadcasts as itself, so `op .+ op`,
+# `2 .* op`, etc. carry `ITensorOperatorStyle`; `+` / `-` / scalar `*` inherit
+# preservation since they lower to broadcasting. `copy` / `similar` unwrap each
+# operator operand to its `state` (the shared `ITensorStyle` machinery does this via
+# `denamed`), build the `ITensor` result, then rewrap as an operator using the
+# codomain/domain split recovered from the operands.
+function BC.BroadcastStyle(arraytype::Type{<:ITensorOperator})
+    return ITensorOperatorStyle{ndims(arraytype)}()
+end
+
+# Recover the codomain/domain split shared by all operator operands of `bc`,
+# erroring if any two operators disagree.
+operator_operands(bc::Broadcasted) = operator_operands(bc.args...)
+operator_operands(arg::ITensorOperator, args...) = (arg, operator_operands(args...)...)
+function operator_operands(arg::Broadcasted, args...)
+    return (operator_operands(arg.args...)..., operator_operands(args...)...)
+end
+operator_operands(arg, args...) = operator_operands(args...)
+operator_operands() = ()
+
+function broadcast_operator_codomain_domain(bc::Broadcasted)
+    ops = operator_operands(bc)
+    op1 = first(ops)
+    cod1 = codomainnames(op1)
+    dom1 = domainnames(op1)
+    for op in Base.tail(ops)
+        (issetequal(codomainnames(op), cod1) && issetequal(domainnames(op), dom1)) ||
+            throw(
+            ArgumentError(
+                "Operator operands disagree on their codomain/domain split: " *
+                    "$((cod1, dom1)) vs $((codomainnames(op), domainnames(op))). " *
+                    "Broadcasting operators requires a matching split."
+            )
+        )
+    end
+    return cod1, dom1
+end
+
+function Base.copy(bc::Broadcasted{<:ITensorOperatorStyle})
+    cod, dom = broadcast_operator_codomain_domain(bc)
+    result = copy(statebroadcasted(bc))
+    return operator(result, cod, dom)
+end
+
+function Base.similar(bc::Broadcasted{<:ITensorOperatorStyle}, elt::Type, ax)
+    cod, dom = broadcast_operator_codomain_domain(bc)
+    result = similar(statebroadcasted(bc), elt, ax)
+    return operator(result, cod, dom)
+end
 
 for f in MATRIX_FUNCTIONS
     @eval begin
-        function Base.$f(a::AbstractITensorOperator)
+        function Base.$f(a::ITensorOperator)
             c = codomainnames(a)
             d = domainnames(a)
             return operator($f(state(a), c, d), c, d)
@@ -138,8 +208,8 @@ for f in MATRIX_FUNCTIONS
 end
 
 # Operator entries for the gram factorizations defined in `tensoralgebra.jl`.
-# Placed here because `AbstractITensorOperator` is defined below
-# `tensoralgebra.jl` in the include order.
+# Placed here because `ITensorOperator` is defined in this file, which comes
+# after `tensoralgebra.jl` in the include order.
 #
 # Per-method docstrings are factored out into `const` strings and attached
 # inside the `@eval` loop via `@doc`. This keeps the loop body uniform when
@@ -147,7 +217,7 @@ end
 # don't share enough structure to warrant `$($f)`-interpolation.
 
 const _gram_eigh_full_operator_docstring = """
-    TensorAlgebra.gram_eigh_full(a::AbstractITensorOperator; kwargs...) -> x
+    TensorAlgebra.gram_eigh_full(a::ITensorOperator; kwargs...) -> x
 
 Gram factorization of a Hermitian positive semi-definite named operator
 `a`, returning `x` such that `x * x_cod ≈ state(a)`, where `x_cod` is
@@ -180,7 +250,7 @@ true
 """
 
 const _gram_eigh_full_with_pinv_operator_docstring = """
-    TensorAlgebra.gram_eigh_full_with_pinv(a::AbstractITensorOperator; kwargs...) -> x, y
+    TensorAlgebra.gram_eigh_full_with_pinv(a::ITensorOperator; kwargs...) -> x, y
 
 Like `TensorAlgebra.gram_eigh_full`, but additionally returns a
 named array `y` that is a left inverse of `x`: `y * x ≈ I` on the
@@ -216,14 +286,14 @@ true
 for f in (:gram_eigh_full, :gram_eigh_full_with_pinv)
     doc_sym = Symbol("_", f, "_operator_docstring")
     @eval begin
-        @doc $doc_sym function TA.$f(a::AbstractITensorOperator; kwargs...)
+        @doc $doc_sym function TA.$f(a::ITensorOperator; kwargs...)
             return TA.$f(state(a), codomainnames(a), domainnames(a); kwargs...)
         end
     end
 end
 
 """
-    Base.one(op::AbstractITensorOperator) -> Id
+    Base.one(op::ITensorOperator) -> Id
 
 Return the identity operator with the same codomain/domain names and shape as
 `op`. `op` is treated as a shape prototype and is not mutated.
@@ -249,7 +319,7 @@ julia> apply(Id, v) ≈ v
 true
 ```
 """
-function Base.one(op::AbstractITensorOperator)
+function Base.one(op::ITensorOperator)
     co, dom = codomainnames(op), domainnames(op)
     return operator(one(state(op), co, dom), co, dom)
 end
@@ -311,46 +381,12 @@ end
 # itself peels to the concrete storage via the generic AbstractITensor
 # method.
 
-function Random.randn!(rng::Random.AbstractRNG, op::AbstractITensorOperator)
+function Random.randn!(rng::Random.AbstractRNG, op::ITensorOperator)
     Random.randn!(rng, state(op))
     return op
 end
 
-function Random.rand!(rng::Random.AbstractRNG, op::AbstractITensorOperator)
+function Random.rand!(rng::Random.AbstractRNG, op::ITensorOperator)
     Random.rand!(rng, state(op))
     return op
-end
-
-struct ITensorOperator{DimName, P <: AbstractITensor{DimName}, D, C} <:
-    AbstractITensorOperator{DimName}
-    parent::P
-    dimnames_bijection::Bijection{D, C}
-end
-
-state(a::ITensorOperator) = a.parent
-Base.parent(a::ITensorOperator) = state(a)
-denamed(a::ITensorOperator) = denamed(state(a))
-
-function ITensorOperator(a::AbstractITensor, codomainnames, domainnames)
-    return ITensorOperator(a, Bijection(domainnames, codomainnames))
-end
-
-parenttype(type::Type{<:ITensorOperator}) = fieldtype(type, :parent)
-statetype(type::Type{<:ITensorOperator}) = parenttype(type)
-
-function nameddimsof(a::ITensorOperator, b::AbstractArray)
-    return ITensorOperator(nameddimsof(state(a), b), a.dimnames_bijection)
-end
-function nameddimsconstructorof(type::Type{<:ITensorOperator})
-    return nameddimsconstructorof(statetype(type))
-end
-
-codomainnames(a::ITensorOperator) = codomain(a.dimnames_bijection)
-domainnames(a::ITensorOperator) = domain(a.dimnames_bijection)
-
-function get_codomain_name(a::ITensorOperator, i)
-    return get(a.dimnames_bijection, i, i)
-end
-function get_domain_name(a::ITensorOperator, i)
-    return get(inverse(a.dimnames_bijection), i, i)
 end

--- a/src/tensoralgebra.jl
+++ b/src/tensoralgebra.jl
@@ -10,10 +10,7 @@ function mul_nameddims(a1::AbstractITensor, a2::AbstractITensor)
     a_dest, dimnames_dest = TA.contract(
         denamed(a1), dimnames(a1), denamed(a2), dimnames(a2)
     )
-    nameddimstype = combine_nameddimsconstructors(
-        nameddimsconstructorof(a1), nameddimsconstructorof(a2)
-    )
-    return nameddimstype(a_dest, dimnames_dest)
+    return nameddims(a_dest, dimnames_dest)
 end
 
 # Left associative fold/reduction.

--- a/test/test_mooncakeext.jl
+++ b/test/test_mooncakeext.jl
@@ -1,6 +1,5 @@
-using ITensorBase: ITensor, Name, NamedUnitRange, blockedperm_nameddims,
-    combine_nameddimsconstructors, dimnames, dimnames_setdiff, inds, name,
-    nameddimsconstructorof, to_inds, uniquename
+using ITensorBase: ITensor, Name, NamedUnitRange, blockedperm_nameddims, dimnames,
+    dimnames_setdiff, inds, name, to_inds, uniquename
 using LinearAlgebra: mul!
 using Mooncake: Mooncake
 using Random: Random
@@ -26,10 +25,6 @@ using Test: @test, @testset
         Mooncake.TestUtils.test_rule(
             rng, blockedperm_nameddims, a1, (i,), (j,); mode, is_primitive
         )
-        Mooncake.TestUtils.test_rule(
-            rng, combine_nameddimsconstructors, ITensor, ITensor;
-            mode, is_primitive
-        )
         Mooncake.TestUtils.test_rule(rng, dimnames, a1; mode, is_primitive)
         Mooncake.TestUtils.test_rule(rng, dimnames, a1, 1; mode, is_primitive)
         Mooncake.TestUtils.test_rule(rng, inds, a1; mode, is_primitive)
@@ -43,7 +38,6 @@ using Test: @test, @testset
             is_primitive
         )
         Mooncake.TestUtils.test_rule(rng, name, i; mode, is_primitive)
-        Mooncake.TestUtils.test_rule(rng, nameddimsconstructorof, a1; mode, is_primitive)
         Mooncake.TestUtils.test_rule(rng, uniquename, i; mode, is_primitive)
         Mooncake.TestUtils.test_rule(rng, uniquename, rng, i; mode, is_primitive)
         Mooncake.TestUtils.test_rule(rng, to_inds, a1, (i, j); mode, is_primitive)

--- a/test/test_nameddims_basics.jl
+++ b/test/test_nameddims_basics.jl
@@ -2,7 +2,7 @@ using Combinatorics: Combinatorics
 using ITensorBase: @names, AbstractITensor, ITensor, Name, NameMismatch,
     NamedDimsCartesianIndex, NamedDimsCartesianIndices, aligndims, aligneddims, apply,
     dename, denamed, denamedtype, dim, dimnames, dimnametype, dims, inds, isnamed, mapinds,
-    name, named, nameddims, namedoneto, product, replacedimnames, replaceinds, setinds
+    name, named, nameddims, namedoneto, product, replacedimnames, replaceinds, setdimnames
 using LinearAlgebra: LinearAlgebra
 using Test: @test, @test_throws, @testset
 using VectorInterface: scalartype
@@ -210,7 +210,7 @@ end
         a′ = denamed(na, ("j", "i"))
         @test a′ isa PermutedDimsArray{elt}
         @test a′ == transpose(a)
-        nb = setinds(na, ("k", "j"))
+        nb = setdimnames(na, ("k", "j"))
         @test inds(nb) == (named(1:3, "k"), named(1:4, "j"))
         @test denamed(nb) == a
         nb = replacedimnames(na, "i" => "k")
@@ -225,7 +225,7 @@ end
         nb = mapinds(n -> n == named(1:3, "i") ? named(1:3, "k") : n, na)
         @test inds(nb) == (named(1:3, "k"), named(1:4, "j"))
         @test denamed(nb) == a
-        nb = setinds(na, named(3, "i") => named(3, "k"))
+        nb = setdimnames(na, named(3, "i") => named(3, "k"))
         na[1, 1] = 11
         @test na[1, 1] == 11
         @test Tuple(size(na)) == (named(3, "i"), named(4, "j"))

--- a/test/test_nameddims_basics.jl
+++ b/test/test_nameddims_basics.jl
@@ -225,7 +225,6 @@ end
         nb = mapinds(n -> n == named(1:3, "i") ? named(1:3, "k") : n, na)
         @test inds(nb) == (named(1:3, "k"), named(1:4, "j"))
         @test denamed(nb) == a
-        nb = setdimnames(na, named(3, "i") => named(3, "k"))
         na[1, 1] = 11
         @test na[1, 1] == 11
         @test Tuple(size(na)) == (named(3, "i"), named(4, "j"))

--- a/test/test_operator.jl
+++ b/test/test_operator.jl
@@ -45,7 +45,7 @@ using Test: @test, @testset
     @test ov ≈ replacedimnames(o * v, "i'" => "i", "j'" => "j")
 end
 
-@testset "one(::AbstractITensorOperator)" begin
+@testset "one(::ITensorOperator)" begin
     # Identity-operator construction: matricized form is the identity matrix.
     i, j, k, l = namedoneto.((2, 3, 2, 3), ("i", "j", "k", "l"))
     op = operator(randn(i, j, k, l), ("i", "j"), ("k", "l"))
@@ -98,7 +98,7 @@ end
     @test eltype(op) === ComplexF32
 end
 
-@testset "randn!(::AbstractITensorOperator) / rand!" begin
+@testset "randn!(::ITensorOperator) / rand!" begin
     op = operator(zeros(3, 3), ("i'",), ("i",))
     rng = StableRNG(123)
     Random.randn!(rng, op)
@@ -109,32 +109,44 @@ end
     @test all(0 .≤ denamed(state(op)) .≤ 1)
 end
 
-@testset "operator linear algebra peels to state" begin
-    # `+`, `-`, and scalar multiplication lower to broadcasting, which peels an
-    # operator to its underlying state (via `broadcastable`), so the result drops
-    # the operator wrapper, matching `*`. Without that, the generic broadcast path
-    # reads `ndims` off the type and throws for a dynamically-ranked parent such as
-    # an `ITensor`. A future version may keep the result an operator instead; this
-    # pins the current contract.
+@testset "operator-preserving broadcasting" begin
+    # `+`, `-`, and scalar multiplication lower to broadcasting. An operator
+    # broadcasts as itself (it is not peeled to its `state`), so these operations
+    # preserve the `ITensorOperator` wrapper and its codomain/domain bijection. `*`
+    # (contraction) is unchanged and still decays to the underlying state.
     o = operator(randn(2, 2), ("i'",), ("i",))
     s = state(o)
     nms = ("i'", "i")
 
-    for r in (o + o, o - o, -o, 2 * o, o * 2, 2 .* o, o .* 2)
-        @test r isa ITensor
-        @test !(r isa ITensorOperator)
+    for r in (o + o, o - o, -o, 2 * o, o * 2, 2 .* o, o .* 2, o ./ 2)
+        @test r isa ITensorOperator
+        @test issetequal(codomainnames(r), ("i'",))
+        @test issetequal(domainnames(r), ("i",))
     end
 
-    @test dename(o + o, nms) ≈ 2 .* dename(s, nms)
-    @test all(iszero, dename(o - o, nms))
-    @test dename(-o, nms) ≈ -dename(s, nms)
-    @test dename(2 * o, nms) ≈ 2 .* dename(s, nms)
-    @test dename(o * 2, nms) ≈ 2 .* dename(s, nms)
-    @test dename(2 .* o, nms) ≈ 2 .* dename(s, nms)
-    @test dename(o .* 2, nms) ≈ 2 .* dename(s, nms)
+    @test dename(state(o + o), nms) ≈ 2 .* dename(s, nms)
+    @test all(iszero, dename(state(o - o), nms))
+    @test dename(state(-o), nms) ≈ -dename(s, nms)
+    @test dename(state(2 * o), nms) ≈ 2 .* dename(s, nms)
+    @test dename(state(o * 2), nms) ≈ 2 .* dename(s, nms)
+    @test dename(state(2 .* o), nms) ≈ 2 .* dename(s, nms)
+    @test dename(state(o .* 2), nms) ≈ 2 .* dename(s, nms)
+    @test dename(state(o ./ 2), nms) ≈ dename(s, nms) ./ 2
+
+    # `*` (contraction) still decays to a plain tensor.
+    @test !((o * o) isa ITensorOperator)
+
+    # Operator combined with a non-operator tensor is rejected.
+    plain = ITensor(randn(2, 2), ("i'", "i"))
+    @test_throws ArgumentError o .+ plain
+
+    # Two operators whose name sets match but whose codomain/domain split differs
+    # are rejected (the split would otherwise be ambiguous).
+    o_swapped = operator(randn(2, 2), ("i",), ("i'",))
+    @test_throws ArgumentError o .+ o_swapped
 end
 
-@testset "gram_eigh_full on AbstractITensorOperator" begin
+@testset "gram_eigh_full on ITensorOperator" begin
     n = 5
     B = randn(n, n)
     A = B * B'  # Hermitian PSD


### PR DESCRIPTION
## Summary

Reconstruct named tensors through the `nameddims` verb. The reconstruction-by-type machinery always resolved to `ITensor` in every reachable case, so it is removed and reconstruction goes through `nameddims`, whose body is `ITensor(a, inds)`. `nameddims` stays as the single construction interface.

Remove `AbstractITensorOperator`. It had a single concrete subtype, `ITensorOperator`, and no downstream subtypes, so its methods now dispatch directly on `ITensorOperator`. The plain-`AbstractITensor` interface fallbacks for `state`, `transpose`, `adjoint`, and `apply` stay.

Preserve the operator wrapper through broadcasting. `op + op`, `op - op`, `2 * op`, and `op / 2` now return an `ITensorOperator` with the same codomain and domain bijection rather than decaying to a plain `ITensor`, since those operations lower to broadcasting. A new `ITensorOperatorStyle` carries this: an operator broadcasts as itself, operator with operator and operator with scalar stay operators, and operator with a non-operator tensor is rejected. Two operators whose name sets match but whose codomain and domain splits differ are also rejected. Contraction (`*`) is unchanged and still decays to the underlying state.

