### PR TITLE
Release v0.6.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorBase"
 uuid = "4795dd04-0d67-49bb-8f44-b89c448a1dc7"
-version = "0.6.0-DEV"
+version = "0.6.0"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]


### PR DESCRIPTION
## Summary

Release v0.6.0 by stripping the `-DEV` prerelease suffix. This is a breaking release collecting the v0.6 cycle: the `NamedDimsArrays` code is relocated into ITensorBase under a from-scratch `AbstractITensor{DimName}` type hierarchy, with the unique-name and operator cleanups on top.

Included PRs:

- Relocate the NamedDimsArrays code into ITensorBase (https://github.com/ITensor/ITensorBase.jl/pull/163)
- Rename the named-array types to an AbstractITensor{DimName} hierarchy (https://github.com/ITensor/ITensorBase.jl/pull/164)
- Drop the AbstractArray supertype from AbstractITensor (https://github.com/ITensor/ITensorBase.jl/pull/169)
- Subtype AbstractNamedUnitRange to AbstractNamedArray, not AbstractUnitRange (https://github.com/ITensor/ITensorBase.jl/pull/170)
- Return dimnames as a Vector and the named axes as Tuples, dropping LittleSet (https://github.com/ITensor/ITensorBase.jl/pull/171)
- Drop the AbstractNamedInteger `<: Integer` subtyping (https://github.com/ITensor/ITensorBase.jl/pull/172)
- Rework named-type parameters around a single `Named` scalar (https://github.com/ITensor/ITensorBase.jl/pull/173)
- Make Index an alias for NamedUnitRange{IndexName} (https://github.com/ITensor/ITensorBase.jl/pull/174)
- Remove factorize, drop TypeParameterAccessors, rename randname to uniquename (https://github.com/ITensor/ITensorBase.jl/pull/175)
- Remove FusedNames and error on ITensor length (https://github.com/ITensor/ITensorBase.jl/pull/176)
- Clean up tensor reconstruction and the operator type (https://github.com/ITensor/ITensorBase.jl/pull/177)
- Mint unique names from RandomDevice and make the id a UUID (https://github.com/ITensor/ITensorBase.jl/pull/178)
