### PR TITLE
Encode String and Symbol unique names in base 62

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorBase"
 uuid = "4795dd04-0d67-49bb-8f44-b89c448a1dc7"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/src/uniquename.jl
+++ b/src/uniquename.jl
@@ -11,8 +11,6 @@ uniquename(rng::AbstractRNG, type::Type) = rand(rng, type)
 uniquename(name; kwargs...) = uniquename(RandomDevice(), name; kwargs...)
 uniquename(rng::AbstractRNG, name; kwargs...) = uniquename(rng, typeof(name); kwargs...)
 
-# Encode 128 random bits in base 62 (`[0-9A-Za-z]`), giving a 22-character name
-# rather than the 36-character dashed hexadecimal of a UUID string.
 function uniquename(rng::AbstractRNG, ::Type{<:AbstractString})
     return string(rand(rng, UInt128); base = 62)
 end

--- a/src/uniquename.jl
+++ b/src/uniquename.jl
@@ -1,5 +1,4 @@
 using Random: AbstractRNG, RandomDevice
-using UUIDs: uuid4
 
 # Generate a new unique name, for example in matrix factorizations.
 # The randomness defaults to `Random.RandomDevice()` (OS entropy) rather than
@@ -12,5 +11,9 @@ uniquename(rng::AbstractRNG, type::Type) = rand(rng, type)
 uniquename(name; kwargs...) = uniquename(RandomDevice(), name; kwargs...)
 uniquename(rng::AbstractRNG, name; kwargs...) = uniquename(rng, typeof(name); kwargs...)
 
-uniquename(rng::AbstractRNG, ::Type{<:AbstractString}) = string(uuid4(rng))
+# Encode 128 random bits in base 62 (`[0-9A-Za-z]`), giving a 22-character name
+# rather than the 36-character dashed hexadecimal of a UUID string.
+function uniquename(rng::AbstractRNG, ::Type{<:AbstractString})
+    return string(rand(rng, UInt128); base = 62)
+end
 uniquename(rng::AbstractRNG, ::Type{Symbol}) = Symbol(uniquename(rng, String))

--- a/src/uniquename.jl
+++ b/src/uniquename.jl
@@ -12,6 +12,8 @@ uniquename(name; kwargs...) = uniquename(RandomDevice(), name; kwargs...)
 uniquename(rng::AbstractRNG, name; kwargs...) = uniquename(rng, typeof(name); kwargs...)
 
 function uniquename(rng::AbstractRNG, ::Type{T}) where {T <: AbstractString}
+    # Base 62 (`[0-9A-Za-z]`) is the largest radix `string` supports, giving the
+    # most compact identifier-safe name: 22 characters for 128 random bits.
     return convert(T, string(rand(rng, UInt128); base = 62))
 end
 uniquename(rng::AbstractRNG, ::Type{Symbol}) = Symbol(uniquename(rng, String))

--- a/src/uniquename.jl
+++ b/src/uniquename.jl
@@ -11,7 +11,7 @@ uniquename(rng::AbstractRNG, type::Type) = rand(rng, type)
 uniquename(name; kwargs...) = uniquename(RandomDevice(), name; kwargs...)
 uniquename(rng::AbstractRNG, name; kwargs...) = uniquename(rng, typeof(name); kwargs...)
 
-function uniquename(rng::AbstractRNG, ::Type{<:AbstractString})
-    return string(rand(rng, UInt128); base = 62)
+function uniquename(rng::AbstractRNG, ::Type{T}) where {T <: AbstractString}
+    return convert(T, string(rand(rng, UInt128); base = 62))
 end
 uniquename(rng::AbstractRNG, ::Type{Symbol}) = Symbol(uniquename(rng, String))


### PR DESCRIPTION
## Summary

Encodes the string outputs of `uniquename` in base 62 (`[0-9A-Za-z]`) rather than as a dashed hexadecimal UUID string, shrinking a freshly minted name from 36 to 22 characters and no longer routing the string and symbol cases through `uuid4`. The encoding draws a full 128 random bits (`rand(rng, UInt128)`), where the previous `uuid4`-based string fixed 6 of them for the UUID version and variant. A requested `AbstractString` subtype is preserved rather than always returning a `String`.

`IndexName` still mints and stores a `UUID`, so index identity and its display are unchanged. This only affects cases where the name type is itself a string or `Symbol`.