### PR TITLE
Compare ITensors by dimension name with eager alignment

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorBase"
 uuid = "4795dd04-0d67-49bb-8f44-b89c448a1dc7"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/src/abstractitensor.jl
+++ b/src/abstractitensor.jl
@@ -405,31 +405,34 @@ function Base.eachindex(
         a1::AbstractITensor,
         a_rest::AbstractITensor...
     )
-    all(a -> issetequal(inds(a1), inds(a)), a_rest) ||
-        throw(NameMismatch("Dimension name mismatch $(inds.((a1, a_rest...)))."))
+    all(a -> issetequal(dimnames(a1), dimnames(a)), a_rest) ||
+        throw(NameMismatch("Dimension name mismatch $(dimnames.((a1, a_rest...)))."))
     # TODO: Check the shapes match.
     return NamedDimsCartesianIndices(inds(a1))
 end
 
+# `dename` (eager), not `denamed` (lazy view): reducing over a lazy permuted view
+# scalar-indexes, which graded arrays forbid.
+
 # Base version ignores dimension names.
 # TODO: Use `mapreduce(isequal, &&, a1, a2)`?
 function Base.isequal(a1::AbstractITensor, a2::AbstractITensor)
-    issetequal(inds(a1), inds(a2)) || return false
-    return isequal(denamed(a1), denamed(a2, inds(a1)))
+    issetequal(dimnames(a1), dimnames(a2)) || return false
+    return isequal(denamed(a1), dename(a2, dimnames(a1)))
 end
 
 # Base version ignores dimension names.
 # TODO: Use `mapreduce(==, &&, a1, a2)`?
 # TODO: Handle `missing` values properly.
 function Base.:(==)(a1::AbstractITensor, a2::AbstractITensor)
-    issetequal(inds(a1), inds(a2)) || return false
-    return denamed(a1) == denamed(a2, inds(a1))
+    issetequal(dimnames(a1), dimnames(a2)) || return false
+    return denamed(a1) == dename(a2, dimnames(a1))
 end
 
 # Base version ignores dimension names.
 function Base.isapprox(a1::AbstractITensor, a2::AbstractITensor; kwargs...)
-    issetequal(inds(a1), inds(a2)) || return false
-    return isapprox(denamed(a1), denamed(a2, inds(a1)); kwargs...)
+    issetequal(dimnames(a1), dimnames(a2)) || return false
+    return isapprox(denamed(a1), dename(a2, dimnames(a1)); kwargs...)
 end
 
 # Generalization of `Base.sort` to Tuples for Julia v1.10 compatibility.


### PR DESCRIPTION
## Summary

Compares `AbstractITensor`s by aligning the second argument eagerly with `dename` rather than through a lazy permuted view. Reducing over a lazy permuted view scalar-indexes the underlying array, which graded arrays forbid, so `==`, `isequal`, and `isapprox` errored on graded `ITensor`s whose dimensions were stored in a different order. Aligning eagerly materializes the permutation first.

These methods and `eachindex` now compare dimension names (`dimnames`) rather than the full named axes (`inds`), so they agree on identity by name without requiring the axis objects themselves to match.