### PR TITLE
Improve user-facing docs and reject indices passed as dimension names

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorBase"
 uuid = "4795dd04-0d67-49bb-8f44-b89c448a1dc7"
-version = "0.8.7"
+version = "0.8.8"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/docs/src/dev_interface.md
+++ b/docs/src/dev_interface.md
@@ -10,12 +10,16 @@ stable user-facing API. For the stable user-facing API, see the [User Interface]
 
 ## Named array types
 
-A concrete tensor type subtypes [`AbstractITensor`](@ref). [`NamedUnitRange`](@ref) is the
-named-range type that a tensor's dimensions are ([`Index`](@ref) is the flavor keyed by an
-index name).
+A concrete tensor type subtypes [`AbstractITensor`](@ref); [`ITensor`](@ref) is the built-in
+dense implementation. Its `ITensor(array, dimnames)` constructor pairs an array with dimension
+names directly; user code usually builds an `ITensor` by calling an array constructor on
+indices or by indexing an array (see [Constructors](@ref)) rather than calling it. The
+underlying named-range model has [`NamedUnitRange`](@ref) as the named-range type that a
+tensor's dimensions are ([`Index`](@ref) is the flavor keyed by an index name).
 
 ```@docs; canonical=false
 AbstractITensor
+ITensor
 NamedUnitRange
 ```
 

--- a/docs/src/user_interface.md
+++ b/docs/src/user_interface.md
@@ -100,15 +100,15 @@ experimental and incompletely supported, and is subject to change.
 
 Matrix factorizations from
 [MatrixAlgebraKit](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl) work on an `ITensor`
-by naming which indices form the codomain (rows) and which form the domain (columns) of the
-matrix the tensor is interpreted as. The factors share a freshly named index over the bond
-between them, so they contract back together with `*`.
+by naming which indices form the codomain (rows) of the matrix the tensor is interpreted as;
+the remaining indices form the domain (columns). The factors share a freshly named index over
+the bond between them, so they contract back together with `*`.
 
-A QR decomposition, splitting index `i` from index `j`:
+A QR decomposition, splitting index `i` off from the rest:
 
 ```@example userinterface
 using MatrixAlgebraKit: qr_compact
-q, r = qr_compact(a, (i,), (j,))
+q, r = qr_compact(a, (i,))
 q * r ≈ a
 ```
 
@@ -116,7 +116,7 @@ A singular value decomposition returns three factors:
 
 ```@example userinterface
 using MatrixAlgebraKit: svd_compact
-u, s, v = svd_compact(a, (i,), (j,))
+u, s, v = svd_compact(a, (i,))
 u * s * v ≈ a
 ```
 

--- a/docs/src/user_interface.md
+++ b/docs/src/user_interface.md
@@ -17,7 +17,6 @@ dimension. Get a tensor's indices with [`inds`](@ref), make distinct copies of a
 
 ```@docs; canonical=false
 Index
-ITensor
 inds
 prime
 noprime
@@ -39,6 +38,14 @@ randn(i, j)
 
 ```@example userinterface
 zeros(i, j)
+```
+
+To name an existing array, index it by the indices: `array[indices...]` returns an `ITensor`
+wrapping `array` with one name per dimension. This is the recommended way to turn an unnamed
+array into a named one.
+
+```@example userinterface
+randn(2, 3)[i, j]
 ```
 
 ## Algebra
@@ -88,3 +95,33 @@ intermediates:
 
 Non-linear broadcasting (functions of one or more tensors, such as `sin.(a)` or `a .^ 2`) is
 experimental and incompletely supported, and is subject to change.
+
+## Factorizations
+
+Matrix factorizations from
+[MatrixAlgebraKit](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl) work on an `ITensor`
+by naming which indices form the codomain (rows) and which form the domain (columns) of the
+matrix the tensor is interpreted as. The factors share a freshly named index over the bond
+between them, so they contract back together with `*`.
+
+A QR decomposition, splitting index `i` from index `j`:
+
+```@example userinterface
+using MatrixAlgebraKit: qr_compact
+q, r = qr_compact(a, (i,), (j,))
+q * r ≈ a
+```
+
+A singular value decomposition returns three factors:
+
+```@example userinterface
+using MatrixAlgebraKit: svd_compact
+u, s, v = svd_compact(a, (i,), (j,))
+u * s * v ≈ a
+```
+
+MatrixAlgebraKit provides many more factorizations, including eigendecompositions, polar
+decompositions, and truncated and full variants, along with keyword options controlling
+them. See the
+[MatrixAlgebraKit documentation](https://quantumkithub.github.io/MatrixAlgebraKit.jl/stable/)
+for the full list and the keyword syntax.

--- a/docs/src/user_interface.md
+++ b/docs/src/user_interface.md
@@ -120,8 +120,9 @@ u, s, v = svd_compact(a, (i,))
 u * s * v ≈ a
 ```
 
-MatrixAlgebraKit provides many more factorizations, including eigendecompositions, polar
-decompositions, and truncated and full variants, along with keyword options controlling
-them. See the
+These are MatrixAlgebraKit factorizations wrapped to act on an `ITensor` by name.
+MatrixAlgebraKit provides many more, including eigendecompositions, polar decompositions, and
+truncated and full variants, along with keyword options controlling them; see the
 [MatrixAlgebraKit documentation](https://quantumkithub.github.io/MatrixAlgebraKit.jl/stable/)
-for the full list and the keyword syntax.
+for the full list and the keyword syntax. The aim is to wrap all of them, but coverage is
+still being filled in, so please open an issue if one you need is not available yet.

--- a/src/abstractitensor.jl
+++ b/src/abstractitensor.jl
@@ -106,8 +106,6 @@ julia> inds(a)
 julia> inds(a, 1)
 named(Base.OneTo(2), :i)
 ```
-
-See also [`dimnames`](@ref), [`nameddims`](@ref).
 """
 function inds end
 # Output the named axes/indices of the named dims array, as a `Tuple` (even though

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1,8 +1,8 @@
 """
-    ITensor(array::AbstractArray, dims)
+    ITensor(array::AbstractArray, dimnames)
 
 A dense tensor whose dimensions are labeled by names instead of ordered by position. It pairs
-an underlying `array` with one name per dimension (`dims`), so contraction, addition, and
+an underlying `array` with one name per dimension (`dimnames`), so contraction, addition, and
 indexing line dimensions up by name. An `ITensor` is usually built by calling `randn`, `zeros`,
 and the like on indices, or through [`nameddims`](@ref), rather than constructed directly.
 
@@ -21,6 +21,14 @@ struct ITensor{DimName} <: AbstractITensor{DimName}
     dimnames::Vector{DimName}
     function ITensor{DimName}(unnamed::AbstractArray, dimnames) where {DimName}
         dimnames = collect(DimName, dimnames)
+        # Catch the common ITensors.jl-style mistake of passing indices as the names.
+        any(dimname -> dimname isa NamedUnitRange, dimnames) && throw(
+            ArgumentError(
+                "Dimension names must be names, not indices (`NamedUnitRange`s), got \
+                $(dimnames). To build an `ITensor` from an array and indices, index the \
+                array instead, as in `array[i, j]`."
+            )
+        )
         ndims(unnamed) == length(dimnames) ||
             throw(ArgumentError("Number of named dims must match ndims."))
         allunique(dimnames) ||
@@ -29,7 +37,7 @@ struct ITensor{DimName} <: AbstractITensor{DimName}
     end
 end
 
-ITensor(unnamed::AbstractArray, dims) = ITensor{eltype(dims)}(unnamed, dims)
+ITensor(unnamed::AbstractArray, dimnames) = ITensor{eltype(dimnames)}(unnamed, dimnames)
 ITensor(a::AbstractITensor, inds) = throw(ArgumentError("Already named."))
 ITensor(a::AbstractITensor) = ITensor(unnamed(a), dimnames(a))
 

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -24,9 +24,9 @@ struct ITensor{DimName} <: AbstractITensor{DimName}
         # Catch the common ITensors.jl-style mistake of passing indices as the names.
         any(dimname -> dimname isa NamedUnitRange, dimnames) && throw(
             ArgumentError(
-                "Dimension names must be names, not indices (`NamedUnitRange`s), got \
-                $(dimnames). To build an `ITensor` from an array and indices, index the \
-                array instead, as in `array[i, j]`."
+                "The `ITensor` constructor takes dimension names only, not indices \
+                (`NamedUnitRange`s), got $(dimnames). To build an `ITensor` from an array \
+                and indices, index the array instead, as in `array[i, j]`."
             )
         )
         ndims(unnamed) == length(dimnames) ||

--- a/src/uniquename.jl
+++ b/src/uniquename.jl
@@ -18,8 +18,6 @@ julia> i = Index(2);
 julia> uniquename(i) != i
 true
 ```
-
-See also [`named`](@ref).
 """
 function uniquename end
 

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -91,8 +91,8 @@ using UUIDs: UUID
         @test_throws ArgumentError ITensor(randn(elt, 4), (:i, :j))
         @test_throws MethodError ITensor(randn(elt, 2, 2), :i, :j)
 
-        # Passing indices as the dimnames (the ITensors.jl idiom) errors; names are
-        # not themselves indices.
+        # The constructor takes names only, not indices, so passing indices (the
+        # ITensors.jl idiom) errors.
         @test_throws ArgumentError ITensor(randn(elt, 2, 2), Index.((2, 2)))
 
         i, j = Index.((3, 4))

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -88,8 +88,12 @@ using UUIDs: UUID
 
         # The number of dimnames must match the array's `ndims`, and the dimnames are
         # passed as a single collection.
-        @test_throws ArgumentError ITensor(randn(elt, 4), Index.((2, 2)))
-        @test_throws MethodError ITensor(randn(elt, 2, 2), Index(2), Index(2))
+        @test_throws ArgumentError ITensor(randn(elt, 4), (:i, :j))
+        @test_throws MethodError ITensor(randn(elt, 2, 2), :i, :j)
+
+        # Passing indices as the dimnames (the ITensors.jl idiom) errors; names are
+        # not themselves indices.
+        @test_throws ArgumentError ITensor(randn(elt, 2, 2), Index.((2, 2)))
 
         i, j = Index.((3, 4))
         a = randn(elt, i, j)


### PR DESCRIPTION
## Summary

Reworks the user-facing documentation and tightens the `ITensor` constructor.

Documentation:

- Document the recommended `array[i, j]` form for naming an existing array as a constructor example, and move the lower-level `ITensor(array, dimnames)` constructor to the Developer Interface, since user code rarely constructs an `ITensor` that way directly.
- Add a Factorizations section to the User Interface with `qr_compact` and `svd_compact` examples, linking to the MatrixAlgebraKit documentation for the full set of factorizations and their keyword options.
- Drop the `See also` references to developer-level functions from the `uniquename` and `inds` docstrings.

Constructor:

- Name the constructor's name argument `dimnames`, matching the inner constructor.
- Error when an index (a `NamedUnitRange`) is passed where a dimension name is expected. This catches the ITensors.jl reflex of writing `ITensor(array, (i, j))`, which previously built a nonsensical tensor whose names were themselves indices, and points to indexing the array instead.
