### PR TITLE
Use the field-based PermutedDims to align permuted broadcasts

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorBase"
 uuid = "4795dd04-0d67-49bb-8f44-b89c448a1dc7"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]
@@ -30,6 +30,10 @@ Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 TensorOperations = "6aa20fa7-93e2-5fca-9bc0-fbd0db3c71a2"
 
+[sources.TensorAlgebra]
+rev = "mf/permuteddims-broadcast"
+url = "https://github.com/ITensor/TensorAlgebra.jl"
+
 [extensions]
 ITensorBaseAdaptExt = "Adapt"
 ITensorBaseMooncakeExt = "Mooncake"
@@ -49,7 +53,7 @@ Mooncake = "0.4.202, 0.5"
 OrderedCollections = "1.6"
 Random = "1.10"
 SimpleTraits = "0.9.4"
-TensorAlgebra = "0.15"
+TensorAlgebra = "0.15.1"
 TensorOperations = "5.3.1"
 TermInterface = "2"
 TupleTools = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -30,10 +30,6 @@ Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 TensorOperations = "6aa20fa7-93e2-5fca-9bc0-fbd0db3c71a2"
 
-[sources.TensorAlgebra]
-rev = "mf/permuteddims-broadcast"
-url = "https://github.com/ITensor/TensorAlgebra.jl"
-
 [extensions]
 ITensorBaseAdaptExt = "Adapt"
 ITensorBaseMooncakeExt = "Mooncake"

--- a/src/abstractnamedtensor.jl
+++ b/src/abstractnamedtensor.jl
@@ -87,16 +87,12 @@ unnamed(a::AbstractNamedTensor) = throw(MethodError(unnamed, a))
 function unnamed(a::AbstractNamedTensor, names)
     return _permuteddims_to(unnamed(a), getperm(dimnames(a), names))
 end
-# Align a misaligned operand for the elementwise broadcast by wrapping it in a lazy permuted
-# view. `TensorAlgebra.PermutedDims` stores the permutation in a field (unlike
-# `Base.PermutedDimsArray`, which encodes it in a type parameter, so a runtime permutation forces
-# runtime type construction), so it builds cheaply and type-stably; it is a broadcast leaf the
-# linear-combination path absorbs via `bipermutedimsopadd!`. Function barrier: `unnamed(a)` is
-# abstractly typed, so dispatching on the concrete array here makes `ndims` a compile-time
-# constant, and the `ntuple(…, Val(ndims))` builds an inferrable `NTuple{N,Int}` permutation
-# rather than a length-non-inferrable `Tuple(::Vector)`.
+# Function barrier: `unnamed(a)` is abstractly typed, so dispatching on the concrete array here
+# makes `ndims` a compile-time constant. Building the permutation as an `ntuple(…, Val(ndims))`
+# (an `NTuple{N,Int}`) rather than `Tuple(perm)` (a length-non-inferrable `Tuple{Vararg{Int}}`)
+# lets `permuteddims` build a concretely-typed wrapper, roughly halving the permute cost.
 @noinline function _permuteddims_to(array::AbstractArray, perm)
-    return TensorAlgebra.PermutedDims(array, ntuple(i -> perm[i], Val(ndims(array))))
+    return permuteddims(array, ntuple(i -> perm[i], Val(ndims(array))))
 end
 unname(a::AbstractNamedTensor, inds) = unnamed(aligndims(a, inds))
 

--- a/src/abstractnamedtensor.jl
+++ b/src/abstractnamedtensor.jl
@@ -87,12 +87,16 @@ unnamed(a::AbstractNamedTensor) = throw(MethodError(unnamed, a))
 function unnamed(a::AbstractNamedTensor, names)
     return _permuteddims_to(unnamed(a), getperm(dimnames(a), names))
 end
-# Function barrier: `unnamed(a)` is abstractly typed, so dispatching on the concrete array here
-# makes `ndims` a compile-time constant. Building the permutation as an `ntuple(…, Val(ndims))`
-# (an `NTuple{N,Int}`) rather than `Tuple(perm)` (a length-non-inferrable `Tuple{Vararg{Int}}`)
-# lets `permuteddims` build a concretely-typed wrapper, roughly halving the permute cost.
+# Align a misaligned operand for the elementwise broadcast by wrapping it in a lazy permuted
+# view. `TensorAlgebra.PermutedDims` stores the permutation in a field (unlike
+# `Base.PermutedDimsArray`, which encodes it in a type parameter, so a runtime permutation forces
+# runtime type construction), so it builds cheaply and type-stably; it is a broadcast leaf the
+# linear-combination path absorbs via `bipermutedimsopadd!`. Function barrier: `unnamed(a)` is
+# abstractly typed, so dispatching on the concrete array here makes `ndims` a compile-time
+# constant, and the `ntuple(…, Val(ndims))` builds an inferrable `NTuple{N,Int}` permutation
+# rather than a length-non-inferrable `Tuple(::Vector)`.
 @noinline function _permuteddims_to(array::AbstractArray, perm)
-    return permuteddims(array, ntuple(i -> perm[i], Val(ndims(array))))
+    return TensorAlgebra.PermutedDims(array, ntuple(i -> perm[i], Val(ndims(array))))
 end
 unname(a::AbstractNamedTensor, inds) = unnamed(aligndims(a, inds))
 

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -1,4 +1,5 @@
-using ..ITensorBase: AbstractNamedTensor, ITensorBase, dimnames, named, nameddims, unnamed
+using ..ITensorBase:
+    AbstractNamedTensor, ITensorBase, dimnames, getperm, named, nameddims, unnamed
 using Base.Broadcast: Broadcast as BC, Broadcasted, broadcasted
 using TensorAlgebra: TensorAlgebra as TA
 
@@ -26,7 +27,18 @@ function broadcasted_unnamed(a::AbstractNamedTensor, names)
     # common case for the rest) needs no permutation, avoiding a `getperm` allocation and the
     # identity `permuteddims` wrapper. Skipping it makes a small add several times slower.
     dimnames(a) == names && return unnamed(a)
-    return unnamed(a, names)
+    return _broadcast_permuteddims_to(unnamed(a), getperm(dimnames(a), names))
+end
+# Broadcasting-only alignment: unlike the public `unnamed(a, names)` (which returns a
+# `Base.PermutedDimsArray`, a full array), this wraps in `TensorAlgebra.PermutedDims`, which stores
+# the permutation in a field rather than a type parameter, so it builds cheaply and type-stably
+# from the runtime permutation and is a broadcast leaf the linear-combination fold absorbs via
+# `bipermutedimsopadd!`. `PermutedDims` has almost no array interface, so it stays confined to this
+# hot path and is never handed back to users. Function barrier: `unnamed(a)` is abstractly typed,
+# so dispatching on the concrete array makes `ndims` a compile-time constant for the inferrable
+# `ntuple(…, Val(ndims))` permutation.
+@noinline function _broadcast_permuteddims_to(array::AbstractArray, perm)
+    return TA.PermutedDims(array, ntuple(i -> perm[i], Val(ndims(array))))
 end
 function broadcasted_unnamed(bc::Broadcasted, names)
     return broadcasted(bc.f, Base.Fix2(broadcasted_unnamed, names).(bc.args)...)

--- a/test/test_linearalgebra.jl
+++ b/test/test_linearalgebra.jl
@@ -1,5 +1,5 @@
 import LinearAlgebra as LA
-using ITensorBase: dimnames, named, unnamed
+using ITensorBase: dimnames, named, unname, unnamed
 using Test: @test, @testset
 
 @testset "LinearAlgebra (eltype=$(elt))" for elt in
@@ -14,5 +14,5 @@ using Test: @test, @testset
     @test unnamed(LA.lmul!(2, copy(a))) ≈ 2 * unnamed(a)
     @test unnamed(LA.rdiv!(copy(a), 2)) ≈ unnamed(a) / 2
     @test unnamed(LA.ldiv!(2, copy(a))) ≈ 2 \ unnamed(a)
-    @test LA.dot(a, b) ≈ LA.dot(unnamed(a), unnamed(b, dimnames(a)))
+    @test LA.dot(a, b) ≈ LA.dot(unnamed(a), unname(b, dimnames(a)))
 end


### PR DESCRIPTION
## Summary

Aligns a misaligned operand in named-tensor broadcasting with `TensorAlgebra.PermutedDims` instead of `Base.PermutedDimsArray`. `PermutedDimsArray` encodes the permutation in a type parameter, so a runtime permutation forces a type-unstable, allocating construction on every permuted add. `PermutedDims` stores the permutation in a field, builds cheaply and type-stably, and is a broadcast leaf the linear-combination fold absorbs via `bipermutedimsopadd!`, so a permuted add no longer pays that type-construction floor and closes most of the gap to an aligned add. The wrapper stays confined to the broadcast alignment path (`broadcasted_unnamed`) and is never returned by the public `unnamed(a, names)`.

Builds on the broadcast-friendly `PermutedDims` from https://github.com/ITensor/TensorAlgebra.jl/pull/198.