### PR TITLE
Add tag verbs, an Index keyword constructor, and factorization bond decoration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorBase"
 uuid = "4795dd04-0d67-49bb-8f44-b89c448a1dc7"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/docs/src/user_interface.md
+++ b/docs/src/user_interface.md
@@ -126,3 +126,20 @@ truncated and full variants, along with keyword options controlling them; see th
 [MatrixAlgebraKit documentation](https://quantumkithub.github.io/MatrixAlgebraKit.jl/stable/)
 for the full list and the keyword syntax. The aim is to wrap all of them, but coverage is
 still being filled in, so please open an issue if one you need is not available yet.
+
+By default each new bond gets a bare freshly minted name. To decorate it, pass a keyword: `name`
+for the single shared bond of the QR, LQ, orthogonal, polar, and null-space factorizations, and
+`leftname`/`rightname` for the two bonds of the central factor in SVD and the eigendecompositions
+(`leftname` on the codomain side, `rightname` on the domain side). Each keyword takes a
+`NamedTuple` of decoration that is applied to the fresh name:
+
+```@example userinterface
+using MatrixAlgebraKit: svd_compact
+using ITensorBase: commonind, tags
+u, s, v = svd_compact(a, (i,); leftname = (; tags = "Link" => "u"), rightname = (; tags = "Link" => "v"))
+tags.((commonind(u, s), commonind(s, v)))
+```
+
+Forward an existing index's decoration onto a new bond with [`decoration`](@ref), and for full
+control over how the name is built pass a callback that receives the index-name type instead of a
+`NamedTuple`.

--- a/docs/src/user_interface.md
+++ b/docs/src/user_interface.md
@@ -136,7 +136,7 @@ for the single shared bond of the QR, LQ, orthogonal, polar, and null-space fact
 ```@example userinterface
 using MatrixAlgebraKit: svd_compact
 using ITensorBase: commonind, tags
-u, s, v = svd_compact(a, (i,); leftname = (; tags = "Link" => "u"), rightname = (; tags = "Link" => "v"))
+u, s, v = svd_compact(a, (i,); leftname = (; tags = "link" => "u"), rightname = (; tags = "link" => "v"))
 tags.((commonind(u, s), commonind(s, v)))
 ```
 

--- a/docs/src/user_interface.md
+++ b/docs/src/user_interface.md
@@ -127,14 +127,14 @@ truncated and full variants, along with keyword options controlling them; see th
 for the full list and the keyword syntax. The aim is to wrap all of them, but coverage is
 still being filled in, so please open an issue if one you need is not available yet.
 
-By default each new bond gets a bare freshly minted name. To decorate it, pass a keyword: `name`
-for the single shared bond of the QR, LQ, orthogonal, polar, and null-space factorizations, and
-`leftname`/`rightname` for the two bonds of the central factor in SVD and the eigendecompositions
-(`leftname` on the codomain side, `rightname` on the domain side). Each keyword takes a
-`NamedTuple` of decoration that is applied to the fresh name:
+The examples above leave each new bond with a bare freshly minted name. To decorate it, pass a
+keyword: `name` for the single shared bond of the QR, LQ, orthogonal, polar, and null-space
+factorizations, and `leftname`/`rightname` for the two bonds of the central factor in SVD and
+the eigendecompositions (`leftname` on the codomain side, `rightname` on the domain side). Each
+keyword takes a `NamedTuple` of decoration that is applied to the fresh name. Here is the same
+SVD, now tagging its two bonds:
 
 ```@example userinterface
-using MatrixAlgebraKit: svd_compact
 using ITensorBase: commonind, tags
 u, s, v = svd_compact(a, (i,); leftname = (; tags = "link" => "u"), rightname = (; tags = "link" => "v"))
 tags.((commonind(u, s), commonind(s, v)))

--- a/src/ITensorBase.jl
+++ b/src/ITensorBase.jl
@@ -8,6 +8,15 @@ export AbstractNamedTensor, NamedTensor, AbstractITensor, ITensor, Index,
 using Compat: @compat
 @compat public @names
 @compat public IndexName, name, nametype, replacedimnames, setname, unnamed, unnamedtype
+@compat public decoration,
+    emptytags,
+    gettag,
+    gettags,
+    hastag,
+    plev,
+    settags,
+    tags,
+    unsettags
 
 # Named-array machinery (relocated from NamedDimsArrays.jl).
 include("isnamed.jl")

--- a/src/index.jl
+++ b/src/index.jl
@@ -40,8 +40,8 @@ end
 function uniquename(rng::AbstractRNG, name::IndexName)
     return IndexName(rng; tags = tags_stored(name), plev = plev(name))
 end
-function uniquename(rng::AbstractRNG, ::Type{<:IndexName})
-    return IndexName(rng)
+function uniquename(rng::AbstractRNG, ::Type{<:IndexName}; tags = (), plev = 0)
+    return IndexName(rng; tags, plev)
 end
 
 # Derive contractions on integer labels: an `IndexName` carries an id and a tag dictionary and is
@@ -77,6 +77,12 @@ function tags(n::IndexName)
     )
 end
 
+"""
+    plev(i)
+
+Return the prime level of an index or index name: a non-negative integer raised by
+[`prime`](@ref) and reset by [`noprime`](@ref).
+"""
 plev(n::IndexName) = getfield(n, :plev)
 
 function Base.:(==)(n1::IndexName, n2::IndexName)
@@ -102,27 +108,111 @@ function Base.hash(n::IndexName, h::UInt)
 end
 
 setuuid(n::IndexName, uuid) = @set n.uuid = uuid
-settags(n::IndexName, tags) = @set n.tags = tags
 setplev(n::IndexName, plev) = @set n.plev = plev
 
+# Internal whole-dictionary install. `settags` is the public merge-semantics verb;
+# this is the raw replace behind the single-key `settag`/`unsettag` primitives.
+setstoredtags(n::IndexName, tags) = @set n.tags = tags
+
+"""
+    hastag(i, key)
+
+Return `true` if the index or index name carries a tag under `key`.
+"""
 hastag(n::IndexName, tagname) = haskey(tags_stored(n), Symbol(tagname))
 
+"""
+    gettag(i, key)
+    gettag(i, key, default)
+
+Return the tag value stored under `key` as a `String`. The two-argument form throws if
+`key` is absent; the three-argument form returns `default` instead. See also
+[`gettags`](@ref).
+"""
 gettag(n::IndexName, tagname) = String(tags_stored(n)[Symbol(tagname)])
 function gettag(n::IndexName, tagname, default)
     t = tags_stored(n)
     k = Symbol(tagname)
     return haskey(t, k) ? String(t[k]) : default
 end
+
+"""
+    gettags(i, keys)
+
+Return the sub-dictionary of the index's tags whose keys are in `keys`, skipping any that
+are absent (so the result never has more keys than requested and never throws). The
+dictionary and string types are implementation details. See also [`gettag`](@ref), [`tags`](@ref).
+"""
+function gettags(n::IndexName, tagnames)
+    t = tags_stored(n)
+    ks = (Symbol(k) for k in tagnames)
+    return SortedDict{String, String}(
+        String(k) => String(t[k]) for k in ks if haskey(t, k)
+    )
+end
+
+# `settag`/`unsettag` are internal single-key primitives; the public plural verbs
+# `settags`/`unsettags` are built on them.
 function settag(n::IndexName, tagname, tag)
     newtags = copy(tags_stored(n))
     newtags[Symbol(tagname)] = Symbol(tag)
-    return settags(n, newtags)
+    return setstoredtags(n, newtags)
 end
 function unsettag(n::IndexName, tagname)
     newtags = copy(tags_stored(n))
     delete!(newtags, Symbol(tagname))
-    return settags(n, newtags)
+    return setstoredtags(n, newtags)
 end
+
+"""
+    settags(i, key => value, ...)
+    settags(i, pairs)
+
+Return a new index or index name with the given tags inserted or overwritten. This is a
+merge: tags under other keys are kept, and a key that already exists is overwritten. Tags
+are given as one or more `key => value` pairs, a collection of pairs, or an `AbstractDict`;
+keys and values may be `String`s or `Symbol`s. See also [`unsettags`](@ref),
+[`emptytags`](@ref).
+"""
+# A lone `Pair` iterates over its two elements, so it needs its own method rather
+# than falling through to the `for (k, v) in ps` loop (cf. `to_tags`).
+settags(n::IndexName, ps::Pair...) = settags(n, ps)
+function settags(n::IndexName, ps)
+    for (k, v) in ps
+        n = settag(n, k, v)
+    end
+    return n
+end
+
+"""
+    unsettags(i, keys)
+
+Return a new index or index name with the tags under each of `keys` removed. Keys that are
+not present are ignored, so this never throws. See also [`settags`](@ref), [`emptytags`](@ref).
+"""
+function unsettags(n::IndexName, tagnames)
+    for k in tagnames
+        n = unsettag(n, k)
+    end
+    return n
+end
+
+"""
+    emptytags(i)
+
+Return a new index or index name with all tags removed.
+"""
+emptytags(n::IndexName) = setstoredtags(n, empty(tags_stored(n)))
+
+"""
+    decoration(i)
+
+Return the tags and prime level of an index or index name as a `NamedTuple`
+`(; tags, plev)`. Splatting it into [`uniquename`](@ref) or the [`Index`](@ref) keyword
+constructor reproduces that decoration on a freshly minted, unique name, as in
+`uniquename(IndexName; decoration(i)...)`.
+"""
+decoration(n::IndexName) = (; tags = tags(n), plev = plev(n))
 
 """
     prime(i)
@@ -217,6 +307,7 @@ end
 
 """
     Index(space)
+    Index(space; tags, plev)
 
 An index of an [`ITensor`](@ref): a named unit range whose name is an [`IndexName`](@ref), a
 freshly minted, unique identifier carrying tags and a prime level. The argument is a space that is converted to a
@@ -225,6 +316,10 @@ range: `Index(2)` makes an index of length `2` over `Base.OneTo(2)`,
 `Index([U1(0) => 2, U1(1) => 3])` makes one over a graded range. Each call mints a new
 name, so two indices built the same way are still distinct, and tensors share a dimension
 only when they share the same `Index`.
+
+The keyword form decorates the freshly minted name, as in `Index(2; tags = "i" => "1", plev = 1)`.
+`tags` accepts the same inputs as [`settags`](@ref) (a pair, a collection of pairs, or an
+`AbstractDict`); `plev` sets the prime level.
 
 # Examples
 
@@ -236,6 +331,13 @@ julia> length(i)
 ```
 """
 const Index = NamedUnitRange{IndexName}
+
+# Keyword constructor: mint a fresh `Index` whose name carries `tags` and a prime level,
+# e.g. `Index(2; tags = "i" => "1", plev = 1)`. `Index(2)` still mints a bare name. Tag
+# inputs match `settags`: a pair, a collection of pairs, or an `AbstractDict`.
+function NamedUnitRange{IndexName}(space; tags = (), plev = 0)
+    return NamedUnitRange{IndexName}(space, uniquename(IndexName; tags, plev))
+end
 
 # `IndexName`-specialized aliases for the named-dims tensor hierarchy. The
 # name-generic primaries are defined earlier (`abstractnamedtensor.jl`,
@@ -275,8 +377,14 @@ hastag(i::Index, tagname) = hastag(name(i), tagname)
 # TODO: Define for `NamedViewIndex`.
 gettag(i::Index, tagname) = gettag(name(i), tagname)
 gettag(i::Index, tagname, default) = gettag(name(i), tagname, default)
+gettags(i::Index, tagnames) = gettags(name(i), tagnames)
 settag(i::Index, tagname, tag) = setname(i, settag(name(i), tagname, tag))
 unsettag(i::Index, tagname) = setname(i, unsettag(name(i), tagname))
+settags(i::Index, ps::Pair...) = setname(i, settags(name(i), ps...))
+settags(i::Index, ps) = setname(i, settags(name(i), ps))
+unsettags(i::Index, tagnames) = setname(i, unsettags(name(i), tagnames))
+emptytags(i::Index) = setname(i, emptytags(name(i)))
+decoration(i::Index) = decoration(name(i))
 
 setplev(i::Index, plev) = setname(i, setplev(name(i), plev))
 prime(i::Index) = setname(i, prime(name(i)))

--- a/src/index.jl
+++ b/src/index.jl
@@ -40,8 +40,8 @@ end
 function uniquename(rng::AbstractRNG, name::IndexName)
     return IndexName(rng; tags = tags_stored(name), plev = plev(name))
 end
-function uniquename(rng::AbstractRNG, ::Type{<:IndexName}; tags = (), plev = 0)
-    return IndexName(rng; tags, plev)
+function uniquename(rng::AbstractRNG, ::Type{<:IndexName}; kwargs...)
+    return IndexName(rng; kwargs...)
 end
 
 # Derive contractions on integer labels: an `IndexName` carries an id and a tag dictionary and is

--- a/src/index.jl
+++ b/src/index.jl
@@ -307,7 +307,6 @@ function Base.show(io::IO, i::IndexName)
 end
 
 """
-    Index(space)
     Index(space; tags, plev)
 
 An index of an [`ITensor`](@ref): a named unit range whose name is an [`IndexName`](@ref), a
@@ -318,9 +317,9 @@ range: `Index(2)` makes an index of length `2` over `Base.OneTo(2)`,
 name, so two indices built the same way are still distinct, and tensors share a dimension
 only when they share the same `Index`.
 
-The keyword form decorates the freshly minted name, as in `Index(2; tags = "i" => "1", plev = 1)`.
-`tags` accepts the same inputs as [`settags`](@ref) (a pair, a collection of pairs, or an
-`AbstractDict`); `plev` sets the prime level.
+`tags` and `plev` decorate the freshly minted name, as in `Index(2; tags = "i" => "1", plev = 1)`,
+and default to no tags and prime level `0`. `tags` accepts the same inputs as [`settags`](@ref)
+(a pair, a collection of pairs, or an `AbstractDict`).
 
 # Examples
 

--- a/src/index.jl
+++ b/src/index.jl
@@ -174,9 +174,9 @@ are given as one or more `key => value` pairs, a collection of pairs, or an `Abs
 keys and values may be `String`s or `Symbol`s. See also [`unsettags`](@ref),
 [`emptytags`](@ref).
 """
-# A lone `Pair` iterates over its two elements, so it needs its own method rather
-# than falling through to the `for (k, v) in ps` loop (cf. `to_tags`).
 settags(n::IndexName, ps::Pair...) = settags(n, ps)
+# A lone `Pair` iterates over its two elements, so the varargs method above needs to exist
+# rather than letting a single pair fall through to the `for (k, v) in ps` loop (cf. `to_tags`).
 function settags(n::IndexName, ps)
     for (k, v) in ps
         n = settag(n, k, v)

--- a/src/index.jl
+++ b/src/index.jl
@@ -207,11 +207,12 @@ emptytags(n::IndexName) = setstoredtags(n, empty(tags_stored(n)))
 """
     decoration(i)
 
-Return the tags and prime level of an index or index name as a `NamedTuple`
-`(; tags, plev)`. Splatting it into [`uniquename`](@ref) or the [`Index`](@ref) keyword
-constructor reproduces that decoration on a freshly minted, unique name, as in
-`uniquename(IndexName; decoration(i)...)`.
+Return the decoration of an index or index name as a `NamedTuple` `(; tags, plev)`. Splatting
+it into [`uniquename`](@ref) or the [`Index`](@ref) keyword constructor reproduces that
+decoration on a freshly minted, unique name, as in `uniquename(IndexName; decoration(i)...)`.
+A name that carries no decoration returns an empty `NamedTuple`.
 """
+decoration(n) = (;)
 decoration(n::IndexName) = (; tags = tags(n), plev = plev(n))
 
 """
@@ -331,13 +332,6 @@ julia> length(i)
 ```
 """
 const Index = NamedUnitRange{IndexName}
-
-# Keyword constructor: mint a fresh `Index` whose name carries `tags` and a prime level,
-# e.g. `Index(2; tags = "i" => "1", plev = 1)`. `Index(2)` still mints a bare name. Tag
-# inputs match `settags`: a pair, a collection of pairs, or an `AbstractDict`.
-function NamedUnitRange{IndexName}(space; tags = (), plev = 0)
-    return NamedUnitRange{IndexName}(space, uniquename(IndexName; tags, plev))
-end
 
 # `IndexName`-specialized aliases for the named-dims tensor hierarchy. The
 # name-generic primaries are defined earlier (`abstractnamedtensor.jl`,

--- a/src/namedunitrange.jl
+++ b/src/namedunitrange.jl
@@ -34,9 +34,10 @@ unnamedtype(::Type{<:NamedUnitRange{<:Any, <:Any, Unnamed}}) where {Unnamed} = U
 # anything `to_range` accepts (an `Integer`, an existing range, or a sector-pair vector
 # when GradedArrays is loaded), so `Index(2)`, `Index(1:3)`, and
 # `Index([U1(0) => 2, U1(1) => 3])` all work. Generic over the name type via `uniquename`,
-# so `Index` (a `NamedUnitRange{IndexName}` alias) needs no `Index`-specific constructor.
-function NamedUnitRange{Name}(space) where {Name}
-    return NamedUnitRange{Name}(space, uniquename(Name))
+# forwarding any keywords (e.g. `tags`/`plev` for `IndexName`) to it, so `Index` (a
+# `NamedUnitRange{IndexName}` alias) needs no `Index`-specific constructor.
+function NamedUnitRange{Name}(space; kwargs...) where {Name}
+    return NamedUnitRange{Name}(space, uniquename(Name; kwargs...))
 end
 # A space and an explicit name, name type fixed by the `Name` parameter: convert the space
 # to a range, then fall through to the base case below.

--- a/src/tensoralgebra.jl
+++ b/src/tensoralgebra.jl
@@ -149,6 +149,15 @@ function unmatricize_nameddims(na::AbstractNamedTensor, splitters::Vararg{Pair, 
     return nameddims(a_split, names_split)
 end
 
+# Canonicalize a bond-name spec to a `nametype -> name` minting function. A `NamedTuple` is
+# splatted into `uniquename` (decoration kwargs such as `tags`/`plev`); a callable is used
+# as-is, for full control over how the name is minted. The default `(;)` reproduces the bare
+# `uniquename(nametype)`. Each factorization exposes one such spec per new bond it mints:
+# `bondname` for a single shared bond, and `rowname`/`colname` for the two legs of the central
+# matrix in SVD and eigendecomposition.
+bondnamer(spec::NamedTuple) = nametype -> uniquename(nametype; spec...)
+bondnamer(f) = f
+
 for f in [
         :left_orth, :left_polar, :lq_compact, :lq_full, :qr_compact, :qr_full,
         :right_orth, :right_polar,
@@ -161,13 +170,14 @@ for f in [
             return $f_nameddims(a, dimnames_codomain, dimnames_domain; kwargs...)
         end
         function $f_nameddims(
-                a::AbstractNamedTensor, dimnames_codomain, dimnames_domain; kwargs...
+                a::AbstractNamedTensor, dimnames_codomain, dimnames_domain;
+                bondname = (;), kwargs...
             )
             codomain = name.(dimnames_codomain)
             domain = name.(dimnames_domain)
             x_unnamed, y_unnamed =
                 TA.$f(unnamed(a), dimnames(a), codomain, domain; kwargs...)
-            name_x = uniquename(dimnametype(a))
+            name_x = bondnamer(bondname)(dimnametype(a))
             name_y = name_x
             dimnames_x = (codomain..., name_x)
             dimnames_y = (name_y, domain...)
@@ -199,15 +209,16 @@ for f in [:svd_compact, :svd_full]
             return $f_nameddims(a, dimnames_codomain, dimnames_domain; kwargs...)
         end
         function $f_nameddims(
-                a::AbstractNamedTensor, dimnames_codomain, dimnames_domain; kwargs...
+                a::AbstractNamedTensor, dimnames_codomain, dimnames_domain;
+                rowname = (;), colname = (;), kwargs...
             )
             codomain = name.(dimnames_codomain)
             domain = name.(dimnames_domain)
             u_unnamed, s_unnamed, v_unnamed = TA.$f(
                 unnamed(a), dimnames(a), codomain, domain; kwargs...
             )
-            name_u = uniquename(dimnametype(a))
-            name_v = uniquename(dimnametype(a))
+            name_u = bondnamer(rowname)(dimnametype(a))
+            name_v = bondnamer(colname)(dimnametype(a))
             dimnames_u = (codomain..., name_u)
             dimnames_s = (name_u, name_v)
             dimnames_v = (name_v, domain...)
@@ -308,15 +319,16 @@ for f in [:eigh_full, :eig_full, :eigh_trunc, :eig_trunc]
             return $f_nameddims(a, dimnames_codomain, dimnames_domain; kwargs...)
         end
         function $f_nameddims(
-                a::AbstractNamedTensor, dimnames_codomain, dimnames_domain; kwargs...
+                a::AbstractNamedTensor, dimnames_codomain, dimnames_domain;
+                rowname = (;), colname = (;), kwargs...
             )
             codomain = name.(dimnames_codomain)
             domain = name.(dimnames_domain)
             d_unnamed, v_unnamed = TA.$f(
                 unnamed(a), dimnames(a), codomain, domain; kwargs...
             )
-            name_d = uniquename(dimnametype(a))
-            name_d′ = uniquename(dimnametype(a))
+            name_d = bondnamer(colname)(dimnametype(a))
+            name_d′ = bondnamer(rowname)(dimnametype(a))
             name_v = name_d
             dimnames_d = (name_d′, name_d)
             dimnames_v = (domain..., name_v)
@@ -355,12 +367,12 @@ function MAK.left_null(
     return left_null_nameddims(a, dimnames_codomain, dimnames_domain; kwargs...)
 end
 function left_null_nameddims(
-        a::AbstractNamedTensor, dimnames_codomain, dimnames_domain; kwargs...
+        a::AbstractNamedTensor, dimnames_codomain, dimnames_domain; bondname = (;), kwargs...
     )
     codomain = name.(dimnames_codomain)
     domain = name.(dimnames_domain)
     n_unnamed = TA.left_null(unnamed(a), dimnames(a), codomain, domain; kwargs...)
-    name_n = uniquename(dimnametype(a))
+    name_n = bondnamer(bondname)(dimnametype(a))
     dimnames_n = (codomain..., name_n)
     return nameddims(n_unnamed, dimnames_n)
 end
@@ -380,12 +392,12 @@ function MAK.right_null(
     return right_null_nameddims(a, dimnames_codomain, dimnames_domain; kwargs...)
 end
 function right_null_nameddims(
-        a::AbstractNamedTensor, dimnames_codomain, dimnames_domain; kwargs...
+        a::AbstractNamedTensor, dimnames_codomain, dimnames_domain; bondname = (;), kwargs...
     )
     codomain = name.(dimnames_codomain)
     domain = name.(dimnames_domain)
     n_unnamed = TA.right_null(unnamed(a), dimnames(a), codomain, domain; kwargs...)
-    name_n = uniquename(dimnametype(a))
+    name_n = bondnamer(bondname)(dimnametype(a))
     dimnames_n = (name_n, domain...)
     return nameddims(n_unnamed, dimnames_n)
 end

--- a/src/tensoralgebra.jl
+++ b/src/tensoralgebra.jl
@@ -153,7 +153,7 @@ end
 # decoration is splatted into `uniquename` (kwargs such as `tags`/`plev`); a callable is used
 # as-is, for full control over how the name is minted. The default `(;)` reproduces the bare
 # `uniquename(nametype)`. Each factorization exposes one such keyword per new bond it mints:
-# `name` for a single shared bond, and `rowname`/`colname` for the two legs of the central
+# `name` for a single shared bond, and `leftname`/`rightname` for the two legs of the central
 # matrix in SVD and eigendecomposition.
 function to_uniquename_function(decoration::NamedTuple)
     return nametype -> uniquename(nametype; decoration...)
@@ -213,15 +213,15 @@ for f in [:svd_compact, :svd_full]
         end
         function $f_nameddims(
                 a::AbstractNamedTensor, dimnames_codomain, dimnames_domain;
-                rowname = (;), colname = (;), kwargs...
+                leftname = (;), rightname = (;), kwargs...
             )
             codomain = name.(dimnames_codomain)
             domain = name.(dimnames_domain)
             u_unnamed, s_unnamed, v_unnamed = TA.$f(
                 unnamed(a), dimnames(a), codomain, domain; kwargs...
             )
-            name_u = to_uniquename_function(rowname)(dimnametype(a))
-            name_v = to_uniquename_function(colname)(dimnametype(a))
+            name_u = to_uniquename_function(leftname)(dimnametype(a))
+            name_v = to_uniquename_function(rightname)(dimnametype(a))
             dimnames_u = (codomain..., name_u)
             dimnames_s = (name_u, name_v)
             dimnames_v = (name_v, domain...)
@@ -323,15 +323,15 @@ for f in [:eigh_full, :eig_full, :eigh_trunc, :eig_trunc]
         end
         function $f_nameddims(
                 a::AbstractNamedTensor, dimnames_codomain, dimnames_domain;
-                rowname = (;), colname = (;), kwargs...
+                leftname = (;), rightname = (;), kwargs...
             )
             codomain = name.(dimnames_codomain)
             domain = name.(dimnames_domain)
             d_unnamed, v_unnamed = TA.$f(
                 unnamed(a), dimnames(a), codomain, domain; kwargs...
             )
-            name_d = to_uniquename_function(colname)(dimnametype(a))
-            name_d′ = to_uniquename_function(rowname)(dimnametype(a))
+            name_d = to_uniquename_function(rightname)(dimnametype(a))
+            name_d′ = to_uniquename_function(leftname)(dimnametype(a))
             name_v = name_d
             dimnames_d = (name_d′, name_d)
             dimnames_v = (domain..., name_v)

--- a/src/tensoralgebra.jl
+++ b/src/tensoralgebra.jl
@@ -153,7 +153,7 @@ end
 # splatted into `uniquename` (decoration kwargs such as `tags`/`plev`); a callable is used
 # as-is, for full control over how the name is minted. The default `(;)` reproduces the bare
 # `uniquename(nametype)`. Each factorization exposes one such spec per new bond it mints:
-# `bondname` for a single shared bond, and `rowname`/`colname` for the two legs of the central
+# `name` for a single shared bond, and `rowname`/`colname` for the two legs of the central
 # matrix in SVD and eigendecomposition.
 bondnamer(spec::NamedTuple) = nametype -> uniquename(nametype; spec...)
 bondnamer(f) = f
@@ -171,13 +171,14 @@ for f in [
         end
         function $f_nameddims(
                 a::AbstractNamedTensor, dimnames_codomain, dimnames_domain;
-                bondname = (;), kwargs...
+                name = (;), kwargs...
             )
-            codomain = name.(dimnames_codomain)
-            domain = name.(dimnames_domain)
+            # `name` is a keyword here, so reach the `name` function through the module.
+            codomain = ITensorBase.name.(dimnames_codomain)
+            domain = ITensorBase.name.(dimnames_domain)
             x_unnamed, y_unnamed =
                 TA.$f(unnamed(a), dimnames(a), codomain, domain; kwargs...)
-            name_x = bondnamer(bondname)(dimnametype(a))
+            name_x = bondnamer(name)(dimnametype(a))
             name_y = name_x
             dimnames_x = (codomain..., name_x)
             dimnames_y = (name_y, domain...)
@@ -367,12 +368,13 @@ function MAK.left_null(
     return left_null_nameddims(a, dimnames_codomain, dimnames_domain; kwargs...)
 end
 function left_null_nameddims(
-        a::AbstractNamedTensor, dimnames_codomain, dimnames_domain; bondname = (;), kwargs...
+        a::AbstractNamedTensor, dimnames_codomain, dimnames_domain; name = (;), kwargs...
     )
-    codomain = name.(dimnames_codomain)
-    domain = name.(dimnames_domain)
+    # `name` is a keyword here, so reach the `name` function through the module.
+    codomain = ITensorBase.name.(dimnames_codomain)
+    domain = ITensorBase.name.(dimnames_domain)
     n_unnamed = TA.left_null(unnamed(a), dimnames(a), codomain, domain; kwargs...)
-    name_n = bondnamer(bondname)(dimnametype(a))
+    name_n = bondnamer(name)(dimnametype(a))
     dimnames_n = (codomain..., name_n)
     return nameddims(n_unnamed, dimnames_n)
 end
@@ -392,12 +394,13 @@ function MAK.right_null(
     return right_null_nameddims(a, dimnames_codomain, dimnames_domain; kwargs...)
 end
 function right_null_nameddims(
-        a::AbstractNamedTensor, dimnames_codomain, dimnames_domain; bondname = (;), kwargs...
+        a::AbstractNamedTensor, dimnames_codomain, dimnames_domain; name = (;), kwargs...
     )
-    codomain = name.(dimnames_codomain)
-    domain = name.(dimnames_domain)
+    # `name` is a keyword here, so reach the `name` function through the module.
+    codomain = ITensorBase.name.(dimnames_codomain)
+    domain = ITensorBase.name.(dimnames_domain)
     n_unnamed = TA.right_null(unnamed(a), dimnames(a), codomain, domain; kwargs...)
-    name_n = bondnamer(bondname)(dimnametype(a))
+    name_n = bondnamer(name)(dimnametype(a))
     dimnames_n = (name_n, domain...)
     return nameddims(n_unnamed, dimnames_n)
 end

--- a/src/tensoralgebra.jl
+++ b/src/tensoralgebra.jl
@@ -149,14 +149,16 @@ function unmatricize_nameddims(na::AbstractNamedTensor, splitters::Vararg{Pair, 
     return nameddims(a_split, names_split)
 end
 
-# Canonicalize a bond-name spec to a `nametype -> name` minting function. A `NamedTuple` is
-# splatted into `uniquename` (decoration kwargs such as `tags`/`plev`); a callable is used
+# Canonicalize a bond-name keyword to a `nametype -> name` minting function. A `NamedTuple` of
+# decoration is splatted into `uniquename` (kwargs such as `tags`/`plev`); a callable is used
 # as-is, for full control over how the name is minted. The default `(;)` reproduces the bare
-# `uniquename(nametype)`. Each factorization exposes one such spec per new bond it mints:
+# `uniquename(nametype)`. Each factorization exposes one such keyword per new bond it mints:
 # `name` for a single shared bond, and `rowname`/`colname` for the two legs of the central
 # matrix in SVD and eigendecomposition.
-bondnamer(spec::NamedTuple) = nametype -> uniquename(nametype; spec...)
-bondnamer(f) = f
+function to_uniquename_function(decoration::NamedTuple)
+    return nametype -> uniquename(nametype; decoration...)
+end
+to_uniquename_function(f) = f
 
 for f in [
         :left_orth, :left_polar, :lq_compact, :lq_full, :qr_compact, :qr_full,
@@ -178,7 +180,7 @@ for f in [
             domain = ITensorBase.name.(dimnames_domain)
             x_unnamed, y_unnamed =
                 TA.$f(unnamed(a), dimnames(a), codomain, domain; kwargs...)
-            name_x = bondnamer(name)(dimnametype(a))
+            name_x = to_uniquename_function(name)(dimnametype(a))
             name_y = name_x
             dimnames_x = (codomain..., name_x)
             dimnames_y = (name_y, domain...)
@@ -218,8 +220,8 @@ for f in [:svd_compact, :svd_full]
             u_unnamed, s_unnamed, v_unnamed = TA.$f(
                 unnamed(a), dimnames(a), codomain, domain; kwargs...
             )
-            name_u = bondnamer(rowname)(dimnametype(a))
-            name_v = bondnamer(colname)(dimnametype(a))
+            name_u = to_uniquename_function(rowname)(dimnametype(a))
+            name_v = to_uniquename_function(colname)(dimnametype(a))
             dimnames_u = (codomain..., name_u)
             dimnames_s = (name_u, name_v)
             dimnames_v = (name_v, domain...)
@@ -328,8 +330,8 @@ for f in [:eigh_full, :eig_full, :eigh_trunc, :eig_trunc]
             d_unnamed, v_unnamed = TA.$f(
                 unnamed(a), dimnames(a), codomain, domain; kwargs...
             )
-            name_d = bondnamer(colname)(dimnametype(a))
-            name_d′ = bondnamer(rowname)(dimnametype(a))
+            name_d = to_uniquename_function(colname)(dimnametype(a))
+            name_d′ = to_uniquename_function(rowname)(dimnametype(a))
             name_v = name_d
             dimnames_d = (name_d′, name_d)
             dimnames_v = (domain..., name_v)
@@ -374,7 +376,7 @@ function left_null_nameddims(
     codomain = ITensorBase.name.(dimnames_codomain)
     domain = ITensorBase.name.(dimnames_domain)
     n_unnamed = TA.left_null(unnamed(a), dimnames(a), codomain, domain; kwargs...)
-    name_n = bondnamer(name)(dimnametype(a))
+    name_n = to_uniquename_function(name)(dimnametype(a))
     dimnames_n = (codomain..., name_n)
     return nameddims(n_unnamed, dimnames_n)
 end
@@ -400,7 +402,7 @@ function right_null_nameddims(
     codomain = ITensorBase.name.(dimnames_codomain)
     domain = ITensorBase.name.(dimnames_domain)
     n_unnamed = TA.right_null(unnamed(a), dimnames(a), codomain, domain; kwargs...)
-    name_n = bondnamer(name)(dimnametype(a))
+    name_n = to_uniquename_function(name)(dimnametype(a))
     dimnames_n = (name_n, domain...)
     return nameddims(n_unnamed, dimnames_n)
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -24,7 +24,7 @@ VectorInterface = "409d34a3-91d5-4945-b6ec-7529ddf182d8"
 WrappedUnions = "325db55a-9c6c-5b90-b1a2-ec87e7a38c44"
 
 [sources.ITensorBase]
-path = "/Users/mfishman/.julia/dev/ITensorBase/.worktrees/mf/nextgen-followups-round1"
+path = ".."
 
 [compat]
 AbstractTrees = "0.4.5"

--- a/test/test_exports.jl
+++ b/test/test_exports.jl
@@ -14,6 +14,8 @@ using Test: @test, @testset
     publics = [
         :IndexName, :name, :nametype, :replacedimnames, :setname, :unnamed,
         :unnamedtype,
+        :decoration, :emptytags, :gettag, :gettags, :hastag, :plev, :settags, :tags,
+        :unsettags,
         Symbol("@names"),
     ]
     if VERSION ≥ v"1.11-"

--- a/test/test_tags.jl
+++ b/test/test_tags.jl
@@ -1,0 +1,118 @@
+using ITensorBase: Index, IndexName, decoration, emptytags, gettag, gettags, hastag, inds,
+    name, plev, prime, settags, tags, uniquename, unsettags
+using MatrixAlgebraKit: eigh_full, left_null, qr_compact, svd_compact
+using Test: @test, @test_throws, @testset
+
+# The new leg of a factor, i.e. the one that is not among the kept indices.
+newbond(t, keep) = only(filter(!in(keep), collect(inds(t))))
+
+@testset "Tags and index decoration" begin
+    @testset "IndexName tag queries" begin
+        n = uniquename(IndexName; tags = "a" => "1", plev = 2)
+        @test tags(n) == Dict("a" => "1")
+        @test plev(n) == 2
+        @test hastag(n, "a")
+        @test !hastag(n, "b")
+        @test gettag(n, "a") == "1"
+        @test gettag(n, "b", "def") == "def"
+        @test_throws KeyError gettag(n, "b")
+    end
+
+    @testset "settags is a merge over several input forms" begin
+        i = Index(2)
+        @test tags(settags(i, "a" => "1")) == Dict("a" => "1")                     # single pair
+        @test tags(settags(i, "a" => "1", "b" => "2")) == Dict("a" => "1", "b" => "2") # varargs
+        @test tags(settags(i, ["a" => "1", "b" => "2"])) == Dict("a" => "1", "b" => "2") # collection
+        @test tags(settags(i, Dict("a" => "1"))) == Dict("a" => "1")               # AbstractDict
+        @test tags(settags(i, :a => :b)) == Dict("a" => "b")                       # Symbols
+        # merge: other keys kept, existing key overwritten
+        j = settags(i, "a" => "1", "b" => "2")
+        @test tags(settags(j, "a" => "9", "c" => "3")) ==
+            Dict("a" => "9", "b" => "2", "c" => "3")
+    end
+
+    @testset "unsettags / emptytags are permissive" begin
+        i = settags(Index(2), "a" => "1", "b" => "2", "c" => "3")
+        @test tags(unsettags(i, ["a", "zzz"])) == Dict("b" => "2", "c" => "3")  # absent key ignored
+        @test tags(unsettags(i, ("a", "b"))) == Dict("c" => "3")
+        @test isempty(tags(emptytags(i)))
+    end
+
+    @testset "gettags returns the present subset" begin
+        i = settags(Index(2), "a" => "1", "b" => "2")
+        @test gettags(i, ["a", "b"]) == Dict("a" => "1", "b" => "2")
+        @test gettags(i, ["a", "zzz"]) == Dict("a" => "1")  # absent key skipped
+        @test isempty(gettags(i, ["zzz"]))
+    end
+
+    @testset "Index keyword constructor" begin
+        i = Index(2; tags = "i" => "1", plev = 1)
+        @test length(i) == 2
+        @test tags(i) == Dict("i" => "1")
+        @test plev(i) == 1
+        @test isempty(tags(Index(2)))                              # bare default unchanged
+        @test Index(2) != Index(2)                                 # fresh unique names
+        @test Index(2; tags = "i" => "1") != Index(2; tags = "i" => "1")
+    end
+
+    @testset "decoration round-trips through uniquename" begin
+        i = Index(2; tags = "Link" => "1", plev = 2)
+        @test decoration(i) == (; tags = Dict("Link" => "1"), plev = 2)
+        k = uniquename(IndexName; decoration(i)...)
+        @test tags(k) == Dict("Link" => "1")
+        @test plev(k) == 2
+        @test k != name(i)                                         # fresh id
+    end
+
+    @testset "factorization bond-name decoration" begin
+        i = Index(2)
+        j = Index(3)
+        a = randn(2, 3)[i, j]
+
+        # Single new bond: `bondname`; default mints a bare bond.
+        q, r = qr_compact(a, (i,), (j,); bondname = (; tags = "Link" => "1"))
+        @test tags(newbond(q, (i,))) == Dict("Link" => "1")
+        @test isempty(tags(newbond(qr_compact(a, (i,), (j,))[1], (i,))))
+
+        # SVD: `rowname` (U-side) and `colname` (V-side); S carries both legs.
+        u, s, v = svd_compact(
+            a, (i,), (j,); rowname = (; tags = "u" => "1"),
+            colname = (; tags = "v" => "1", plev = 1)
+        )
+        ub = newbond(u, (i,))
+        vb = newbond(v, (j,))
+        @test tags(ub) == Dict("u" => "1")
+        @test tags(vb) == Dict("v" => "1")
+        @test plev(vb) == 1
+        @test Set(collect(inds(s))) == Set([ub, vb])
+
+        # A callable spec gets full control over minting.
+        u2, _, _ =
+            svd_compact(a, (i,), (j,); rowname = nt -> uniquename(nt; tags = "c" => "9"))
+        @test tags(newbond(u2, (i,))) == Dict("c" => "9")
+
+        # `decoration` forwards an existing index's decoration onto a fresh bond.
+        src = Index(2; tags = "Link" => "7", plev = 2)
+        u3, _, _ = svd_compact(a, (i,), (j,); rowname = decoration(src))
+        @test tags(newbond(u3, (i,))) == Dict("Link" => "7")
+        @test plev(newbond(u3, (i,))) == 2
+
+        # Eigen: D's legs are row/col (independent); V shares the col leg.
+        s1 = Index(2)
+        s1p = prime(s1)
+        m = randn(2, 2)
+        m = m + transpose(m)
+        h = m[s1, s1p]
+        d, vec = eigh_full(
+            h, (s1,), (s1p,); rowname = (; tags = "row" => "1"),
+            colname = (; tags = "col" => "1")
+        )
+        @test Set(Dict.(tags.(collect(inds(d))))) ==
+            Set([Dict("row" => "1"), Dict("col" => "1")])
+        @test tags(newbond(vec, (s1p,))) == Dict("col" => "1")
+
+        # Single new bond on the null spaces.
+        n = left_null(a, (i,), (j,); bondname = (; tags = "n" => "1"))
+        @test tags(newbond(n, (i,))) == Dict("n" => "1")
+    end
+end

--- a/test/test_tags.jl
+++ b/test/test_tags.jl
@@ -75,10 +75,10 @@ newbond(t, keep) = only(filter(!in(keep), collect(inds(t))))
         @test tags(newbond(q, (i,))) == Dict("Link" => "1")
         @test isempty(tags(newbond(qr_compact(a, (i,), (j,))[1], (i,))))
 
-        # SVD: `rowname` (U-side) and `colname` (V-side); S carries both legs.
+        # SVD: `leftname` (U-side) and `rightname` (V-side); S carries both legs.
         u, s, v = svd_compact(
-            a, (i,), (j,); rowname = (; tags = "u" => "1"),
-            colname = (; tags = "v" => "1", plev = 1)
+            a, (i,), (j,); leftname = (; tags = "u" => "1"),
+            rightname = (; tags = "v" => "1", plev = 1)
         )
         ub = newbond(u, (i,))
         vb = newbond(v, (j,))
@@ -89,24 +89,24 @@ newbond(t, keep) = only(filter(!in(keep), collect(inds(t))))
 
         # A callable spec gets full control over minting.
         u2, _, _ =
-            svd_compact(a, (i,), (j,); rowname = nt -> uniquename(nt; tags = "c" => "9"))
+            svd_compact(a, (i,), (j,); leftname = nt -> uniquename(nt; tags = "c" => "9"))
         @test tags(newbond(u2, (i,))) == Dict("c" => "9")
 
         # `decoration` forwards an existing index's decoration onto a fresh bond.
         src = Index(2; tags = "Link" => "7", plev = 2)
-        u3, _, _ = svd_compact(a, (i,), (j,); rowname = decoration(src))
+        u3, _, _ = svd_compact(a, (i,), (j,); leftname = decoration(src))
         @test tags(newbond(u3, (i,))) == Dict("Link" => "7")
         @test plev(newbond(u3, (i,))) == 2
 
-        # Eigen: D's legs are row/col (independent); V shares the col leg.
+        # Eigen: D's legs are left/right (independent); V shares the right leg.
         s1 = Index(2)
         s1p = prime(s1)
         m = randn(2, 2)
         m = m + transpose(m)
         h = m[s1, s1p]
         d, vec = eigh_full(
-            h, (s1,), (s1p,); rowname = (; tags = "row" => "1"),
-            colname = (; tags = "col" => "1")
+            h, (s1,), (s1p,); leftname = (; tags = "row" => "1"),
+            rightname = (; tags = "col" => "1")
         )
         @test Set(Dict.(tags.(collect(inds(d))))) ==
             Set([Dict("row" => "1"), Dict("col" => "1")])

--- a/test/test_tags.jl
+++ b/test/test_tags.jl
@@ -56,10 +56,10 @@ newbond(t, keep) = only(filter(!in(keep), collect(inds(t))))
     end
 
     @testset "decoration round-trips through uniquename" begin
-        i = Index(2; tags = "Link" => "1", plev = 2)
-        @test decoration(i) == (; tags = Dict("Link" => "1"), plev = 2)
+        i = Index(2; tags = "link" => "1", plev = 2)
+        @test decoration(i) == (; tags = Dict("link" => "1"), plev = 2)
         k = uniquename(IndexName; decoration(i)...)
-        @test tags(k) == Dict("Link" => "1")
+        @test tags(k) == Dict("link" => "1")
         @test plev(k) == 2
         @test k != name(i)                                         # fresh id
         @test decoration("x") == (;)                               # undecorated name
@@ -71,8 +71,8 @@ newbond(t, keep) = only(filter(!in(keep), collect(inds(t))))
         a = randn(2, 3)[i, j]
 
         # Single new bond: `name`; default mints a bare bond.
-        q, r = qr_compact(a, (i,), (j,); name = (; tags = "Link" => "1"))
-        @test tags(newbond(q, (i,))) == Dict("Link" => "1")
+        q, r = qr_compact(a, (i,), (j,); name = (; tags = "link" => "1"))
+        @test tags(newbond(q, (i,))) == Dict("link" => "1")
         @test isempty(tags(newbond(qr_compact(a, (i,), (j,))[1], (i,))))
 
         # SVD: `leftname` (U-side) and `rightname` (V-side); S carries both legs.
@@ -93,9 +93,9 @@ newbond(t, keep) = only(filter(!in(keep), collect(inds(t))))
         @test tags(newbond(u2, (i,))) == Dict("c" => "9")
 
         # `decoration` forwards an existing index's decoration onto a fresh bond.
-        src = Index(2; tags = "Link" => "7", plev = 2)
+        src = Index(2; tags = "link" => "7", plev = 2)
         u3, _, _ = svd_compact(a, (i,), (j,); leftname = decoration(src))
-        @test tags(newbond(u3, (i,))) == Dict("Link" => "7")
+        @test tags(newbond(u3, (i,))) == Dict("link" => "7")
         @test plev(newbond(u3, (i,))) == 2
 
         # Eigen: D's legs are left/right (independent); V shares the right leg.

--- a/test/test_tags.jl
+++ b/test/test_tags.jl
@@ -69,8 +69,8 @@ newbond(t, keep) = only(filter(!in(keep), collect(inds(t))))
         j = Index(3)
         a = randn(2, 3)[i, j]
 
-        # Single new bond: `bondname`; default mints a bare bond.
-        q, r = qr_compact(a, (i,), (j,); bondname = (; tags = "Link" => "1"))
+        # Single new bond: `name`; default mints a bare bond.
+        q, r = qr_compact(a, (i,), (j,); name = (; tags = "Link" => "1"))
         @test tags(newbond(q, (i,))) == Dict("Link" => "1")
         @test isempty(tags(newbond(qr_compact(a, (i,), (j,))[1], (i,))))
 
@@ -112,7 +112,7 @@ newbond(t, keep) = only(filter(!in(keep), collect(inds(t))))
         @test tags(newbond(vec, (s1p,))) == Dict("col" => "1")
 
         # Single new bond on the null spaces.
-        n = left_null(a, (i,), (j,); bondname = (; tags = "n" => "1"))
+        n = left_null(a, (i,), (j,); name = (; tags = "n" => "1"))
         @test tags(newbond(n, (i,))) == Dict("n" => "1")
     end
 end

--- a/test/test_tags.jl
+++ b/test/test_tags.jl
@@ -62,6 +62,7 @@ newbond(t, keep) = only(filter(!in(keep), collect(inds(t))))
         @test tags(k) == Dict("Link" => "1")
         @test plev(k) == 2
         @test k != name(i)                                         # fresh id
+        @test decoration("x") == (;)                               # undecorated name
     end
 
     @testset "factorization bond-name decoration" begin


### PR DESCRIPTION
## Summary

Reworks the index tag interface around key-value tags and adds a consistent way to decorate the names that the `Index` constructor and the factorizations mint.

Because tags are key-value pairs, the plural verbs are now merge-based and permissive. `settags` inserts or overwrites the given tags (as one or more pairs, a collection of pairs, or an `AbstractDict`), `unsettags` removes a collection of keys, and `emptytags` clears them. Setting a tag that already exists overwrites it, and removing one that is absent is a no-op. These verbs, together with `gettags`, `gettag`, `hastag`, `tags`, `plev`, and `decoration`, are now `public`. `settags` previously replaced the entire tag dictionary and now merges, but it was neither exported nor `public`, so this is a non-breaking patch release.

`Index(2; tags = "i" => "1", plev = 1)` mints a fresh index carrying the given tags and prime level, and `uniquename(IndexName; tags, plev)` does the same at the name level.

Factorizations can now decorate the bonds they create. Each new bond takes a keyword, `name` for the single shared bond of the `qr`/`lq`/`orth`/`polar`/`null` family, and `leftname`/`rightname` for the two legs of the central matrix in `svd` and the eigendecompositions. Each accepts either a `NamedTuple` of decoration that is splatted into `uniquename` (`leftname = (; tags = "link" => "1")`) or a name-minting callback for full control over how the name is built. `decoration(i)` returns an index's `(; tags, plev)` for forwarding an existing bond's decoration onto a fresh one. The default leaves bonds bare, so existing calls mint the same undecorated names they do today. The Factorizations section of the user interface manual documents these keywords.

Also restores `test/Project.toml`'s `[sources.ITensorBase]` path to `..`, which a machine-specific absolute path had replaced.
