### PR TITLE
Fix `Array` and `trivialrange` for TensorKit-backed ITensors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorBase"
 uuid = "4795dd04-0d67-49bb-8f44-b89c448a1dc7"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/ext/ITensorBaseTensorKitExt.jl
+++ b/ext/ITensorBaseTensorKitExt.jl
@@ -15,9 +15,12 @@ function ITensorBase.NamedUnitRange(unnamed::ElementarySpace, name)
     return ITensorBase.NamedUnitRange{typeof(name), Int, typeof(unnamed)}(unnamed, name)
 end
 
-# `conj(index)` lowers to `named(conj(space), name)`, so `named` on a space must rebuild a
-# `NamedUnitRange` rather than fall through to the generic (array-shaped) `Named`.
-ITensorBase.named(r::ElementarySpace, name) = ITensorBase.NamedUnitRange(r, name)
+# `conj(index)` lowers to `named(conj(space), name)`, and `trivialrange` mints a fresh axis via
+# `namedunitrange(space, name)`, so both must rebuild a `NamedUnitRange` over the space rather than
+# fall through to the generic (array-shaped) `Named`. `named` delegates to `namedunitrange`, as the
+# core `AbstractUnitRange` path does.
+ITensorBase.namedunitrange(r::ElementarySpace, name) = ITensorBase.NamedUnitRange(r, name)
+ITensorBase.named(r::ElementarySpace, name) = ITensorBase.namedunitrange(r, name)
 
 # The flat length of a space-backed axis is its total (dense) dimension, so `size`/`length`
 # of a `TensorMap`-backed ITensor report dense dimensions.

--- a/src/abstractnamedtensor.jl
+++ b/src/abstractnamedtensor.jl
@@ -280,7 +280,15 @@ end
 
 # These are defined since the Base versions assume the eltype and ndims are known
 # at compile time, which isn't true for ITensors.
-Base.Array(a::AbstractNamedTensor) = Array(unnamed(a))
+# Workaround: `Array(::TensorKit.AbstractTensorMap)` is not defined yet (it should be), so a
+# TensorKit-backed ITensor cannot densify through the plain `Array(unnamed(a))`. Go through
+# `convert(Array, ...)`, which TensorKit does support, and restore the copy the `Array` constructor
+# would have made (`convert` returns the storage unchanged when it is already an `Array`). Once
+# TensorKit defines `Array(::AbstractTensorMap)`, simplify this back to `Array(unnamed(a))`.
+function Base.Array(a::AbstractNamedTensor)
+    array = convert(Array, unnamed(a))
+    return array === unnamed(a) ? copy(array) : array
+end
 Base.Array{T}(a::AbstractNamedTensor) where {T} = Array{T}(unnamed(a))
 Base.Array{T, N}(a::AbstractNamedTensor) where {T, N} = Array{T, N}(unnamed(a))
 Base.AbstractArray{T}(a::AbstractNamedTensor) where {T} = AbstractArray{T, ndims(a)}(a)

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -142,6 +142,8 @@ using UUIDs: UUID
         @test eltype(a′) === elt
         @test a′ isa Matrix{elt}
         @test a′ == unnamed(a)
+        # `Array` returns a fresh copy, not the storage object itself.
+        @test a′ !== unnamed(a)
 
         i, j = Index.((3, 4))
         a = randn(elt, i, j)

--- a/test/test_tensorkitext.jl
+++ b/test/test_tensorkitext.jl
@@ -78,6 +78,20 @@ using Test: @test, @test_throws, @testset
         q, r = qr_compact(a3, (i,), (j, k))
         @test sca((q * r) * w) ≈ sca(a3 * w)
 
+        # `Array` densifies a `TensorMap`-backed ITensor to a plain dense array (a fresh copy).
+        @test Array(a) isa Array{elt}
+        @test Array(a) == convert(Array, unnamed(a))
+
+        # `trivialrange` mints a fresh trivial axis over the native space (used e.g. by the
+        # boundary-MPS setup), routing through the `namedunitrange(::ElementarySpace, name)` overload.
+        t1 = TensorAlgebra.trivialrange(i)
+        @test t1 isa Index
+        @test length(t1) == 1
+        tn = TensorAlgebra.trivialrange(i, 3)
+        @test tn isa Index
+        @test length(tn) == 3
+        @test name(tn) != name(i)
+
         # Map-shaped construction forwards the codomain/domain split to the `TensorMap`:
         # `randn((i,), (j,))` stores a `Vi ← Vj` map rather than flattening all-codomain.
         # Following the `similar_map` convention the domain appears dualized in the outward


### PR DESCRIPTION
## Summary

Fixes two gaps in the TensorKit backend: densifying a `TensorMap`-backed ITensor to a dense `Array`, and minting a trivial axis over a native TensorKit space. `Array(::AbstractNamedTensor)` now densifies through `convert(Array, ...)` rather than the `Array` constructor, so storage that is not an `AbstractArray`, such as a TensorKit `TensorMap`, goes through its own `convert(Array, ...)` method. It restores the copy the `Array` constructor would have made when `convert` returns the storage unchanged. This is a workaround until TensorKit defines `Array(::AbstractTensorMap)`, at which point it can go back to `Array(unnamed(a))`. The TensorKit extension also overloads `namedunitrange(::ElementarySpace, name)`, not just `named`, which `trivialrange` uses to mint the fresh axis (needed by the boundary-MPS setup).