### PR TITLE
Make replacedimnames a no-op for an empty replacement set

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorBase"
 uuid = "4795dd04-0d67-49bb-8f44-b89c448a1dc7"
-version = "0.11.2"
+version = "0.11.3"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/src/abstractnamedtensor.jl
+++ b/src/abstractnamedtensor.jl
@@ -519,6 +519,9 @@ function replacedimnames end
 # (`name(i) => name(j)`). `dimnames(a)` holds names, so a raw-index key would never match and
 # silently no-op.
 function replacedimnames(a::AbstractNamedTensor, replacements::Pair...)
+    # Base's `replace(::AbstractArray)` with no pairs throws (unlike `replace(::AbstractString)`),
+    # so short-circuit the empty case: with no replacements there is nothing to relabel.
+    isempty(replacements) && return a
     replacements = map(p -> name(first(p)) => name(last(p)), replacements)
     new_dimnames = replace(dimnames(a), replacements...)
     return nameddims(unnamed(a), new_dimnames)

--- a/test/test_nameddims_basics.jl
+++ b/test/test_nameddims_basics.jl
@@ -233,6 +233,13 @@ end
         nb = mapinds(n -> n == named(1:3, "i") ? named(1:3, "k") : n, na)
         @test inds(nb) == [named(1:3, "k"), named(1:4, "j")]
         @test unnamed(nb) == a
+        # An empty replacement set relabels nothing.
+        nb = replacedimnames(na)
+        @test inds(nb) == inds(na)
+        @test unnamed(nb) == a
+        nb = replaceinds(na)
+        @test inds(nb) == inds(na)
+        @test unnamed(nb) == a
         na[1, 1] = 11
         @test na[1, 1] == 11
         @test size(na) == (3, 4)


### PR DESCRIPTION
## Summary

`replacedimnames`, and `replaceinds` which delegates to it, now return the tensor unchanged when given no replacement pairs instead of throwing. Base's `replace(::AbstractArray)` with no pairs errors with `promote_valuetype()`, unlike `replace(::AbstractString)` which returns the string, so the empty case has to be short-circuited explicitly. This lets callers pass a computed, possibly-empty set of relabelings without guarding the empty case themselves.