### PR TITLE
Rename named-wrapper `value` field to `unnamed`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorBase"
 uuid = "4795dd04-0d67-49bb-8f44-b89c448a1dc7"
-version = "0.13.2"
+version = "0.13.3"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/src/named.jl
+++ b/src/named.jl
@@ -5,7 +5,7 @@
 # under the numeric contract, and inherited fallbacks risk silently dropping the
 # name. So it supplies the integer-like surface it needs directly.
 struct Named{Name, Unnamed}
-    value::Unnamed
+    unnamed::Unnamed
     name::Name
 end
 
@@ -112,7 +112,7 @@ See also [`unnamed`](@ref), [`nametype`](@ref).
 function unnamedtype end
 
 # Minimal interface.
-unnamed(i::Named) = i.value
+unnamed(i::Named) = i.unnamed
 name(i::Named) = i.name
 
 """
@@ -132,7 +132,7 @@ named(value, name) = Named(value, name)
 
 # Derived interface.
 setname(i::Named, name) = named(unnamed(i), name)
-setvalue(i::Named, value) = named(value, name(i))
+setunnamed(i::Named, unnamed) = named(unnamed, name(i))
 
 unnamedtype(::Type{<:Named{<:Any, Unnamed}}) where {Unnamed} = Unnamed
 nametype(::Type{<:Named{Name}}) where {Name} = Name
@@ -167,7 +167,7 @@ function Base.show(io::IO, i::Named)
 end
 
 # Integer interface, for the named-integer case `NamedInteger`.
-Base.:-(i::NamedInteger) = setvalue(i, -unnamed(i))
+Base.:-(i::NamedInteger) = setunnamed(i, -unnamed(i))
 
 ## TODO: Support this, we need to define `NamedFloat`, `NamedReal`, `NamedNumber`, etc.
 ## This is used in `LinearAlgebra.norm`, for now we just overload that directly.
@@ -177,10 +177,10 @@ Base.:-(i::NamedInteger) = setvalue(i, -unnamed(i))
 ##   return named(unnamed(i1) * i2, name(i1))
 ## end
 
-Base.zero(i::NamedInteger) = setvalue(i, zero(unnamed(i)))
-Base.one(i::NamedInteger) = setvalue(i, one(unnamed(i)))
+Base.zero(i::NamedInteger) = setunnamed(i, zero(unnamed(i)))
+Base.one(i::NamedInteger) = setunnamed(i, one(unnamed(i)))
 Base.signbit(i::NamedInteger) = signbit(unnamed(i))
-Base.unsigned(i::NamedInteger) = setvalue(i, unsigned(unnamed(i)))
+Base.unsigned(i::NamedInteger) = setunnamed(i, unsigned(unnamed(i)))
 
 # Used in bounds checking when indexing with named dimensions.
 function Base.:<(i1::NamedInteger, i2::NamedInteger)

--- a/src/namedarray.jl
+++ b/src/namedarray.jl
@@ -1,10 +1,10 @@
 struct NamedArray{Name, UnnamedT, N, Unnamed <: AbstractArray{UnnamedT, N}} <:
     AbstractNamedArray{Name, UnnamedT, N}
-    value::Unnamed
+    unnamed::Unnamed
     name::Name
 end
 
 # Minimal interface.
-unnamed(a::NamedArray) = a.value
+unnamed(a::NamedArray) = a.unnamed
 name(a::NamedArray) = a.name
 unnamedtype(::Type{<:NamedArray{<:Any, <:Any, <:Any, Unnamed}}) where {Unnamed} = Unnamed

--- a/src/namedunitrange.jl
+++ b/src/namedunitrange.jl
@@ -18,15 +18,15 @@ named(1:3, :i)
 See also [`Index`](@ref), [`named`](@ref).
 """
 struct NamedUnitRange{Name, UnnamedT, Unnamed} <: AbstractNamedVector{Name, UnnamedT}
-    # The `value` is usually an integer `AbstractUnitRange`, but the bound is left open so a
-    # backend can store a richer axis object directly, e.g. a native TensorKit space, which is
-    # not an `AbstractUnitRange` but is its own axis (see the TensorKit extension).
-    value::Unnamed
+    # The `unnamed` value is usually an integer `AbstractUnitRange`, but the bound is left open
+    # so a backend can store a richer axis object directly, e.g. a native TensorKit space, which
+    # is not an `AbstractUnitRange` but is its own axis (see the TensorKit extension).
+    unnamed::Unnamed
     name::Name
 end
 
 # Minimal interface.
-unnamed(i::NamedUnitRange) = i.value
+unnamed(i::NamedUnitRange) = i.unnamed
 name(i::NamedUnitRange) = i.name
 unnamedtype(::Type{<:NamedUnitRange{<:Any, <:Any, Unnamed}}) where {Unnamed} = Unnamed
 


### PR DESCRIPTION
## Summary

Renames the wrapped-object field of `Named`, `NamedArray`, and `NamedUnitRange` from `value` to `unnamed`, so the field name matches the `unnamed` accessor that reads it. Also renames the internal `setvalue` helper to `setunnamed`, keeping it symmetric with the existing `setname`.